### PR TITLE
Remove any traces of `actionview`

### DIFF
--- a/lib/next_rails/gem_info.rb
+++ b/lib/next_rails/gem_info.rb
@@ -1,15 +1,5 @@
-begin
-  require "action_view"
-rescue LoadError
-  puts "ActionView not available"
-end
-
 module NextRails
   class GemInfo
-    if defined?(ActionView)
-      include ActionView::Helpers::DateHelper
-    end
-
     class NullGemInfo < GemInfo
       def initialize; end
 

--- a/lib/next_rails/gem_info.rb
+++ b/lib/next_rails/gem_info.rb
@@ -42,11 +42,7 @@ module NextRails
     end
 
     def age
-      if respond_to?(:time_ago_in_words)
-        "#{time_ago_in_words(created_at)} ago"
-      else
-        created_at.strftime("%b %e, %Y")
-      end
+      created_at.strftime("%b %e, %Y")
     end
 
     def sourced_from_git?

--- a/spec/ten_years_rails/gem_info_spec.rb
+++ b/spec/ten_years_rails/gem_info_spec.rb
@@ -19,22 +19,10 @@ RSpec.describe NextRails::GemInfo do
       end
     end
 
-    context "when ActionView is available" do
-      it "returns a time ago" do
-        expect(subject.age).to eq("about 12 hours ago")
-      end
-    end
+    let(:result) { now.strftime("%b %e, %Y") }
 
-    context "when ActionView is not available" do
-      let(:result) { now.strftime("%b %e, %Y") }
-
-      before do
-        subject.instance_eval('undef :time_ago_in_words')
-      end
-
-      it "returns a date" do
-        expect(subject.age).to eq(result)
-      end
+    it "returns a date" do
+      expect(subject.age).to eq(result)
     end
   end
 end


### PR DESCRIPTION
Hi there, 

I believe it would be best to not use `actionview` at all in this gem. It causes problems and narrows our options in terms of older rubies/rails apps. 

So this PR drops any hint of `actionview` for this tool and it solves #21. 

Please check it out. 

Thanks! 