### PR TITLE
[FEATURE] `bundle_report outdated` outputs in JSON format when passed optional argument

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 * [FEATURE: Initialize the Gemfile.next.lock to avoid major version jumps when used without an initial Gemfile.next.lock](https://github.com/fastruby/next_rails/pull/25)
 * [FEATURE: Drop `actionview` dependency because it is not really used](https://github.com/fastruby/next_rails/pull/26)
+* [FEATURE: `bundle_report outdated` outputs in JSON format when passed optional argument](https://github.com/fastruby/next_rails/pull/33)
 
 # v1.0.4 / 2021-04-09 [(commits)](https://github.com/fastruby/next_rails/compare/v1.0.3...v1.0.4)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 * [FEATURE: Initialize the Gemfile.next.lock to avoid major version jumps when used without an initial Gemfile.next.lock](https://github.com/fastruby/next_rails/pull/25)
 * [FEATURE: Drop `actionview` dependency because it is not really used](https://github.com/fastruby/next_rails/pull/26)
-* [FEATURE: `bundle_report outdated` outputs in JSON format when passed optional argument](https://github.com/fastruby/next_rails/pull/33)
+* [FEATURE: `bundle_report outdated` outputs in JSON format when passed optional argument](https://github.com/fastruby/next_rails/pull/35)
 
 # v1.0.4 / 2021-04-09 [(commits)](https://github.com/fastruby/next_rails/compare/v1.0.3...v1.0.4)
 

--- a/README.md
+++ b/README.md
@@ -29,10 +29,17 @@ Learn about your Gemfile and see what needs updating.
 ```bash
 # Show all out-of-date gems
 bundle_report outdated
+
 # Show five oldest, out-of-date gems
 bundle_report outdated | head -n 5
+
+# Show all out-of-date gems in machine readable JSON format
+bundle_report outdated --json
+
 # Show gems that don't work with Rails 5.2.0
 bundle_report compatibility --rails-version=5.2.0
+
+# Show the usual help message
 bundle_report --help
 ```
 

--- a/exe/bundle_report
+++ b/exe/bundle_report
@@ -17,6 +17,7 @@ at_exit do
       Examples:
         #{$0} compatibility --rails-version 5.0
         #{$0} outdated
+        #{$0} outdated --json
     EOS
 
     opts.separator ""
@@ -28,6 +29,10 @@ at_exit do
 
     opts.on("--include-rails-gems", "Include Rails gems in compatibility report (defaults to false)") do
       options[:include_rails_gems] = true
+    end
+
+    opts.on("--json", "Output JSON in outdated report (defaults to false)") do
+      options[:json] = true
     end
 
     opts.on_tail("-h", "--help", "Show this message") do
@@ -47,7 +52,7 @@ at_exit do
   report_type = ARGV.first
 
   case report_type
-  when "outdated" then NextRails::BundleReport.outdated
+  when "outdated" then NextRails::BundleReport.outdated(options.fetch(:json, false))
   else
     NextRails::BundleReport.compatibility(rails_version: options.fetch(:rails_version, "5.0"), include_rails_gems: options.fetch(:include_rails_gems, false))
   end

--- a/lib/next_rails/bundle_report.rb
+++ b/lib/next_rails/bundle_report.rb
@@ -58,12 +58,43 @@ module NextRails
       header
     end
 
-    def self.outdated
+    def self.outdated(human_readable = true)
       gems = NextRails::GemInfo.all
       out_of_date_gems = gems.reject(&:up_to_date?).sort_by(&:created_at)
       sourced_from_git = gems.select(&:sourced_from_git?)
 
-      output_to_stdout(out_of_date_gems, gems.count, sourced_from_git.count)
+      if human_readable
+        output_to_stdout(out_of_date_gems, gems.count, sourced_from_git.count)
+      else
+        output_to_json(out_of_date_gems, gems.count, sourced_from_git.count)
+      end
+    end
+
+    def self.output_to_json(out_of_date_gems, total_gem_count, sourced_from_git_count)
+      obj = build_json(out_of_date_gems, total_gem_count, sourced_from_git_count)
+      puts JSON.pretty_generate(obj)
+    end
+
+    def self.build_json(out_of_date_gems, total_gem_count, sourced_from_git_count)
+      output = Hash.new { [] }
+      out_of_date_gems.each do |gem|
+        output[:gems] += [
+          {
+            name: gem.name,
+            installed_version: gem.version,
+            installed_age: gem.age,
+            latest_version: gem.latest_version.version,
+            latest_age: gem.latest_version.age
+          }
+        ]
+      end
+
+      output.merge(
+        {
+          sourced_from_git_count: sourced_from_git_count,
+          total_gem_count: total_gem_count
+        }
+      )
     end
 
     def self.output_to_stdout(out_of_date_gems, total_gem_count, sourced_from_git_count)

--- a/lib/next_rails/bundle_report.rb
+++ b/lib/next_rails/bundle_report.rb
@@ -63,14 +63,6 @@ module NextRails
       out_of_date_gems = gems.reject(&:up_to_date?).sort_by(&:created_at)
       sourced_from_git = gems.select(&:sourced_from_git?)
 
-      output_to_io(out_of_date_gems, gems.count, sourced_from_git.count)
-    end
-
-    def self.outdated
-      gems = NextRails::GemInfo.all
-      out_of_date_gems = gems.reject(&:up_to_date?).sort_by(&:created_at)
-      sourced_from_git = gems.select(&:sourced_from_git?)
-
       output_to_stdout(out_of_date_gems, gems.count, sourced_from_git.count)
     end
 

--- a/lib/next_rails/bundle_report.rb
+++ b/lib/next_rails/bundle_report.rb
@@ -61,22 +61,36 @@ module NextRails
     def self.outdated
       gems = NextRails::GemInfo.all
       out_of_date_gems = gems.reject(&:up_to_date?).sort_by(&:created_at)
-      percentage_out_of_date = ((out_of_date_gems.count / gems.count.to_f) * 100).round
       sourced_from_git = gems.select(&:sourced_from_git?)
 
-      out_of_date_gems.each do |_gem|
-        header = "#{_gem.name} #{_gem.version}"
+      output_to_io(out_of_date_gems, gems.count, sourced_from_git.count)
+    end
+
+    def self.outdated
+      gems = NextRails::GemInfo.all
+      out_of_date_gems = gems.reject(&:up_to_date?).sort_by(&:created_at)
+      sourced_from_git = gems.select(&:sourced_from_git?)
+
+      output_to_stdout(out_of_date_gems, gems.count, sourced_from_git.count)
+    end
+
+    def self.output_to_stdout(out_of_date_gems, total_gem_count, sourced_from_git_count)
+      out_of_date_gems.each do |gem|
+        header = "#{gem.name} #{gem.version}"
 
         puts <<~MESSAGE
-          #{header.bold.white}: released #{_gem.age} (latest version, #{_gem.latest_version.version}, released #{_gem.latest_version.age})
+          #{header.bold.white}: released #{gem.age} (latest version, #{gem.latest_version.version}, released #{gem.latest_version.age})
         MESSAGE
       end
 
-      puts ""
-      puts <<~MESSAGE
-        #{"#{sourced_from_git.count}".yellow} gems are sourced from git
-        #{"#{out_of_date_gems.length}".red} of the #{gems.count} gems are out-of-date (#{percentage_out_of_date}%)
+      percentage_out_of_date = ((out_of_date_gems.count / total_gem_count.to_f) * 100).round
+      footer = <<~MESSAGE
+        #{sourced_from_git_count.to_s.yellow} gems are sourced from git
+        #{out_of_date_gems.count.to_s.red} of the #{total_gem_count} gems are out-of-date (#{percentage_out_of_date}%)
       MESSAGE
+
+      puts ''
+      puts footer
     end
   end
 end

--- a/lib/next_rails/bundle_report.rb
+++ b/lib/next_rails/bundle_report.rb
@@ -58,15 +58,15 @@ module NextRails
       header
     end
 
-    def self.outdated(human_readable = true)
+    def self.outdated(output_in_json)
       gems = NextRails::GemInfo.all
       out_of_date_gems = gems.reject(&:up_to_date?).sort_by(&:created_at)
       sourced_from_git = gems.select(&:sourced_from_git?)
 
-      if human_readable
-        output_to_stdout(out_of_date_gems, gems.count, sourced_from_git.count)
-      else
+      if output_in_json
         output_to_json(out_of_date_gems, gems.count, sourced_from_git.count)
+      else
+        output_to_stdout(out_of_date_gems, gems.count, sourced_from_git.count)
       end
     end
 
@@ -78,7 +78,7 @@ module NextRails
     def self.build_json(out_of_date_gems, total_gem_count, sourced_from_git_count)
       output = Hash.new { [] }
       out_of_date_gems.each do |gem|
-        output[:gems] += [
+        output[:outdated_gems] += [
           {
             name: gem.name,
             installed_version: gem.version,

--- a/spec/bundle_report_spec.rb
+++ b/spec/bundle_report_spec.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+require 'date'
+require 'tempfile'
+require_relative 'spec_helper'
+require_relative '../lib/next_rails/bundle_report'
+
+RSpec.describe NextRails::BundleReport do
+  describe '.outdated' do
+    let(:mock_version) { Struct.new(:version, :age) }
+    let(:mock_gem) { Struct.new(:name, :version, :age, :latest_version, :up_to_date?, :created_at, :sourced_from_git?) }
+    let(:format_str) { '%b %e, %Y' }
+    let(:alpha_date) { Date.parse('2022-01-01') }
+    let(:alpha_age) { alpha_date.strftime(format_str) }
+    let(:bravo_date) { Date.parse('2022-02-02') }
+    let(:bravo_age) { bravo_date.strftime(format_str) }
+    let(:charlie_date) { Date.parse('2022-03-03') }
+    let(:charlie_age) { charlie_date.strftime(format_str) }
+
+    before do
+      allow(NextRails::GemInfo).to receive(:all).and_return(
+        [
+          mock_gem.new('alpha', '0.0.1', alpha_age, mock_version.new('0.0.2', bravo_age), false, alpha_date, false),
+          mock_gem.new('bravo', '0.2.0', bravo_age, mock_version.new('0.2.2', charlie_age), false, bravo_date, true)
+        ]
+      )
+    end
+
+    context 'when writing human-readable output' do
+      subject { described_class.outdated }
+
+      it 'invokes $stdout.puts properly', :aggregate_failures do
+        allow($stdout)
+          .to receive(:puts)
+          .with("#{'alpha 0.0.1'.bold.white}: released #{alpha_age} (latest version, 0.0.2, released #{bravo_age})\n")
+        allow($stdout)
+          .to receive(:puts)
+          .with("#{'bravo 0.2.0'.bold.white}: released #{bravo_age} (latest version, 0.2.2, released #{charlie_age})\n")
+        allow($stdout).to receive(:puts).with('')
+        allow($stdout).to receive(:puts).with(<<~EO_MULTLINE_STRING)
+          #{'1'.yellow} gems are sourced from git
+          #{'2'.red} of the 2 gems are out-of-date (100%)
+        EO_MULTLINE_STRING
+
+        subject
+      end
+    end
+  end
+end

--- a/spec/bundle_report_spec.rb
+++ b/spec/bundle_report_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe NextRails::BundleReport do
     end
 
     context 'when writing human-readable output' do
-      subject { described_class.outdated }
+      subject { described_class.outdated(false) }
 
       it 'invokes $stdout.puts properly', :aggregate_failures do
         allow($stdout)
@@ -54,7 +54,7 @@ RSpec.describe NextRails::BundleReport do
 
         expect(NextRails::BundleReport.build_json(out_of_date_gems, gems.count, sourced_from_git.count)).to eq(
           {
-            gems: [
+            outdated_gems: [
               { name: 'alpha', installed_version: '0.0.1', installed_age: alpha_age, latest_version: '0.0.2',
                 latest_age: bravo_age },
               { name: 'bravo', installed_version: '0.2.0', installed_age: bravo_age, latest_version: '0.2.2',

--- a/spec/bundle_report_spec.rb
+++ b/spec/bundle_report_spec.rb
@@ -45,5 +45,26 @@ RSpec.describe NextRails::BundleReport do
         subject
       end
     end
+
+    context 'when writing JSON output' do
+      it 'JSON is correctly formatted' do
+        gems = NextRails::GemInfo.all
+        out_of_date_gems = gems.reject(&:up_to_date?).sort_by(&:created_at)
+        sourced_from_git = gems.select(&:sourced_from_git?)
+
+        expect(NextRails::BundleReport.build_json(out_of_date_gems, gems.count, sourced_from_git.count)).to eq(
+          {
+            gems: [
+              { name: 'alpha', installed_version: '0.0.1', installed_age: alpha_age, latest_version: '0.0.2',
+                latest_age: bravo_age },
+              { name: 'bravo', installed_version: '0.2.0', installed_age: bravo_age, latest_version: '0.2.2',
+                latest_age: charlie_age }
+            ],
+            sourced_from_git_count: sourced_from_git.count,
+            total_gem_count: gems.count
+          }
+        )
+      end
+    end
   end
 end


### PR DESCRIPTION
`bundle_report outdated` now takes an optional `--json` argument that causes the output to be in JSON format. This allows easier machine parsing of outdated gems in CI/CD pipeline or periodic audit jobs. For example: `exe/bundle_report outdated --json` in the the current project directory returns:
```
{
  "outdated_gems": [
    {
      "name": "rake",
      "installed_version": "10.5.0",
      "installed_age": "Jan 13, 2016",
      "latest_version": "13.0.6",
      "latest_age": "Jul  9, 2021"
    },
    {
      "name": "simplecov-html",
      "installed_version": "0.10.2",
      "installed_age": "Aug 14, 2017",
      "latest_version": "0.12.3",
      "latest_age": "Sep 23, 2020"
    },
    {
      "name": "simplecov",
      "installed_version": "0.17.1",
      "installed_age": "Sep 16, 2019",
      "latest_version": "0.21.2",
      "latest_age": "Jan  9, 2021"
    },
    {
      "name": "bundler",
      "installed_version": "2.1.4",
      "installed_age": "Jun  7, 2021",
      "latest_version": "2.3.9",
      "latest_age": "Mar  9, 2022"
    }
  ],
  "sourced_from_git_count": 0,
  "total_gem_count": 15
}
```

Added specs to verify the original human readable output, plus the new JSON output.

I will abide by the [code of conduct](CODE_OF_CONDUCT.md).

Closes #34.