### PR TITLE
if shitlist path does not exist, fix the failure with ENOENT

### DIFF
--- a/lib/deprecation_tracker.rb
+++ b/lib/deprecation_tracker.rb
@@ -130,9 +130,17 @@ class DeprecationTracker
 
   def save
     new_shitlist = create_temp_shitlist
+    create_if_shitlist_path_does_not_exist
     FileUtils.cp(new_shitlist.path, shitlist_path)
   ensure
     new_shitlist.delete if new_shitlist
+  end
+
+  def create_if_shitlist_path_does_not_exist
+    dirname = File.dirname(shitlist_path)
+    unless File.directory?(dirname)
+      FileUtils.mkdir_p(dirname)
+    end
   end
 
   def create_temp_shitlist

--- a/spec/deprecation_tracker_spec.rb
+++ b/spec/deprecation_tracker_spec.rb
@@ -104,6 +104,33 @@ RSpec.describe DeprecationTracker do
       expect(File.read(shitlist_path)).to eq(expected_json)
     end
 
+    it "creates the directory if shitlist directory does not exist" do
+      FileUtils.mkdir_p("/tmp/test")
+      shitlist_path = Tempfile.new("tmp", "/tmp/test").path
+      FileUtils.rm(shitlist_path)
+      shitlist_path
+      subject = DeprecationTracker.new(shitlist_path)
+
+      subject.bucket = "bucket 1"
+      subject.add("b")
+      subject.add("b")
+      subject.add("a")
+
+      subject.save
+
+      expected_json = <<-JSON.chomp
+{
+  "bucket 1": [
+    "a",
+    "b",
+    "b"
+  ]
+}
+      JSON
+      expect(File.read(shitlist_path)).to eq(expected_json)
+      FileUtils.rm_r "/tmp/test"
+    end
+
     it "combines recorded and stored messages" do
       setup_tracker = DeprecationTracker.new(shitlist_path)
       setup_tracker.bucket = "bucket 1"


### PR DESCRIPTION
Description:

Fixes: https://github.com/fastruby/next_rails/issues/13

It checks if the path passed as the shitlist file exists or not. If it does not exist, it creates the directory.

I will abide by the [code of conduct](CODE_OF_CONDUCT.md).