### PR TITLE
added 'next_rails' exe to support cli option for version

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,15 @@ deprecations --help # For more options and examples
 
 Right now, the path to the shitlist is hardcoded so make sure you store yours at `spec/support/deprecations.shitlist.json`.
 
+#### `next_rails` command
+
+You can use `next_rails` to fetch the version of the gem installed.
+
+```bash
+next_rails --version
+next_rails --help # For more options and examples
+```
+
 ### Dual-boot Rails next
 
 This command helps you dual-boot your application.

--- a/exe/next_rails
+++ b/exe/next_rails
@@ -1,0 +1,29 @@
+#!/usr/bin/env ruby
+require "optparse"
+require "next_rails/version"
+
+options = {}
+option_parser = OptionParser.new do |opts|
+  opts.banner = <<-MESSAGE
+    Usage: #{__FILE__.to_s} [options]
+
+    Examples:
+      bin/next_rails --version info # Show the version of the gem installed
+  MESSAGE
+
+  opts.on("--version", "show version of the gem") do
+    options[:version] = true
+  end
+
+  opts.on_tail("-h", "--help", "Prints this help") do
+    puts opts
+    exit
+  end
+end
+
+option_parser.parse!
+
+if options.fetch(:version, false)
+  puts NextRails::VERSION
+  exit 2
+end


### PR DESCRIPTION
Closes https://github.com/fastruby/next_rails/issues/15

Description:

There are a few executables or command-line options already present for example bundle_report, deprecations, next, 
but none of them really reflects the whole gem as such. 

So I have added a new executable called `next_rails` and we can use it like `next_rails --version`.
This is a general convention followed by libraries that provide options like version, 
for ex: puma gem provides `puma --version` as a command-line option.

I have also updated the READme so the documentation covers the mention of this new option.

I will abide by the [code of conduct](CODE_OF_CONDUCT.md).