### PR TITLE
Add support to use DeprecationTracker with Minitest

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,18 @@ RSpec.configure do |config|
 end
 ```
 
-We don't use MiniTest, so there isn't a prebuilt config for it but I suspect it's pretty similar to `DeprecationTracker.track_rspec`.
+If using minitest, add this somewhere close to the top of your `test_helper.rb`:
+
+```ruby
+# Tracker deprecation messages in each file
+if ENV["DEPRECATION_TRACKER"]
+  DeprecationTracker.track_minitest(
+    shitlist_path: "test/support/deprecation_warning.shitlist.json",
+    mode: ENV["DEPRECATION_TRACKER"],
+    transform_message: -> (message) { message.gsub("#{Rails.root}/", "") }
+  )
+end
+```
 
 Once you have that, you can start using deprecation tracking in your tests:
 
@@ -121,7 +132,7 @@ Execute:
     $ next --init
 
 Init will create a Gemfile.next and an initialized Gemfile.next.lock.
-The Gemfile.next.lock is initialized with the contents of your existing 
+The Gemfile.next.lock is initialized with the contents of your existing
 Gemfile.lock lock file. We initialize the Gemfile.next.lock to prevent
 major version jumps when running the next version of Rails.
 

--- a/README.md
+++ b/README.md
@@ -67,6 +67,8 @@ if ENV["DEPRECATION_TRACKER"]
 end
 ```
 
+> Keep in mind this is currently not compatible with the `minitest/parallel_fork` gem!
+
 Once you have that, you can start using deprecation tracking in your tests:
 
 ```bash

--- a/spec/deprecation_tracker_spec.rb
+++ b/spec/deprecation_tracker_spec.rb
@@ -220,6 +220,31 @@ RSpec.describe DeprecationTracker do
     end
   end
 
+  describe "#after_run" do
+    let(:shitlist_path) { "some_path" }
+
+    it "calls save if in save mode" do
+      tracker = DeprecationTracker.new(shitlist_path, nil, :save)
+      expect(tracker).to receive(:save)
+      expect(tracker).not_to receive(:compare)
+      tracker.after_run
+    end
+
+    it "calls compare if in compare mode" do
+      tracker = DeprecationTracker.new(shitlist_path, nil, "compare")
+      expect(tracker).not_to receive(:save)
+      expect(tracker).to receive(:compare)
+      tracker.after_run
+    end
+
+    it "does not save nor compare if mode is invalid" do
+      tracker = DeprecationTracker.new(shitlist_path, nil, "random_stuff")
+      expect(tracker).not_to receive(:save)
+      expect(tracker).not_to receive(:compare)
+      tracker.after_run
+    end
+  end
+
   describe DeprecationTracker::KernelWarnTracker do
     it "captures Kernel#warn" do
       warn_messages = []


### PR DESCRIPTION
Description:

This PR adds a `track_minitest` method that does something kinda similar to `track_rspec` but for Minitest.

I updated the README to show how to use this too, it's slightly different.


I tested this using this sample app that has some tests for both RSpec and Minitest https://github.com/fastruby/js-coverage-sample-app.

- I added the config described in the README
- I added some code that I know would trigger a deprecation warning (call `ActiveRecord::Base.allow_unsafe_raw_sql` inside tests)
- I ran both `rails spec` and `rails test:all`
- Verified the `support/...shitlist.json` files are there for `/test` and `/spec` with the same content

I will abide by the [code of conduct](CODE_OF_CONDUCT.md).