### PR TITLE
Make behavior arguments optional

### DIFF
--- a/lib/deprecation_tracker.rb
+++ b/lib/deprecation_tracker.rb
@@ -64,7 +64,9 @@ class DeprecationTracker
     transform_message = opts[:transform_message]
     deprecation_tracker = DeprecationTracker.new(shitlist_path, transform_message, mode)
     if defined?(ActiveSupport)
-      ActiveSupport::Deprecation.behavior << -> (message, _callstack, _deprecation_horizon, _gem_name) { deprecation_tracker.add(message) }
+      ActiveSupport::Deprecation.behavior << -> (message, _callstack = nil, _deprecation_horizon = nil, _gem_name = nil) {
+        deprecation_tracker.add(message)
+      }
     end
     KernelWarnTracker.callbacks << -> (message) { deprecation_tracker.add(message) }
 


### PR DESCRIPTION
Description:

This PR fixes #23 by making the last 2 arguments for the custom behavior optional.

Before Rails 5.2, the behavior only supported 2 arguments and ActiveSupport would call the behavior with only 2 arguments (then the error `given 2, expected 4`). By making the unused arguments optional the code works fine in older Rails versions.

Behaviors in Rails < 5.2: https://github.com/rails/rails/blob/5-1-stable/activesupport/lib/active_support/deprecation/behaviors.rb#L12
Behaviors since Rails >= 5.2: https://github.com/rails/rails/blob/5-2-stable/activesupport/lib/active_support/deprecation/behaviors.rb#L14

I tested this by creating a Rails 5.1.7 project, adding next_rails to track deprecations and manually added a deprecation warning both before and after this change and I can confirm this fixes the issue.

I will abide by the [code of conduct](CODE_OF_CONDUCT.md).