### PR TITLE
Update the code of conduct link in PR template

### DIFF
--- a/pull_request_template.md
+++ b/pull_request_template.md
@@ -6,4 +6,4 @@ Description:
 
 Please include a summary of the change and which issue is fixed or which feature is introduced. If changes to the behavior are made, clearly describe what changes.
 
-I will abide by the [code of conduct](CODE_OF_CONDUCT.md).
+I will abide by the [code of conduct](https://github.com/fastruby/next_rails/blob/main/CODE_OF_CONDUCT.md).


### PR DESCRIPTION
This closes issue #45 

- [ ] Add an entry to `CHANGELOG.md` that links to this PR under the "main (unreleased)" heading.

Description:

This updates the link to the code of conduct in the PR template. I'm not sure how this can be tested, I think it has to be merged first. 

I will abide by the [code of conduct](CODE_OF_CONDUCT.md).