### PR TITLE
Add FEATURE REQUEST and BUG REPORT templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,51 @@
+---
+name: Bug report
+about: Create a report to help us improve
+title: "[BUG] "
+labels: bug
+assignees: ""
+---
+
+**IMPORTANT: please make sure you ask yourself all intro questions and fill all sections of the template.**
+
+**Before we start...:**
+
+- [ ] I checked the documentation and found no answer
+- [ ] I checked to make sure that this issue has not already been filed
+- [ ] I'm reporting the issue to the correct repository (for multi-repository projects)
+
+**Version, Branch, or Commit:**
+
+What branch/commit/version of "next_rails" you are using?
+
+**Expected behavior:**
+
+Please include a detailed description of the behavior you were expecting when you encountered this issue.
+
+**Actual behavior:**
+
+Please include a detailed description of the actual behavior of the application.
+
+**Steps to reproduce:**
+
+How do I achieve this behavior? Use the following format to provide a step-by-step guide:
+
+1. Step 1: ...
+2. Step 2: ...
+
+**Context and environment:**
+
+Provide any relevant information about your setup (Customize the list accordingly based on what info is relevant to this project)
+
+1. Version of the software the issue is being opened for.
+2. Operating System
+3. Operating System version
+4. Ruby version
+
+_Delete any information that is not relevant._
+
+**Logs**
+
+Include relevant log snippets or files here.
+
+**I will abide by the [code of conduct](https://github.com/fastruby/next_rails/blob/main/CODE_OF_CONDUCT.md)**

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,40 @@
+---
+name: Feature request
+about: Request a new feature
+title: "[REQUEST]"
+labels: enhancement
+assignees: ""
+---
+
+**IMPORTANT: please make sure you ask yourself all intro questions and fill all sections of the template.**
+
+**Before we start...:**
+
+- [ ] I checked the documentation and didn't find this feature
+- [ ] I checked to make sure that this feature has not already been requested
+
+**Branch/Commit:**
+
+Inform what branch/commit/version of "next_rails" you are using.
+
+**Describe the feature:**
+
+Please include a detailed description of the feature you are requesting and any detail on it’s expected behavior.
+
+> **As a \<role name\>** > **I do \<something\>** > **And then I do \<another action\>** > **And I see \<some result\>**
+
+**Problem:**
+
+Please include a detailed description of the problem this feature would solve.
+
+> **As a \<role name\>** > **I want to \<do something\>** > **So that I can achieve a \<goal\>**
+
+**Mockups:**
+
+Include any mockup idea related to the requested feature if it applies.
+
+**Resources:**
+
+If you have resources related to the implementation or research for this feature, add them here.
+
+**I will abide by the [code of conduct](https://github.com/fastruby/next_rails/blob/main/CODE_OF_CONDUCT.md)**


### PR DESCRIPTION
This closes issue #14 

- [ ] Add an entry to `CHANGELOG.md` that links to this PR under the "main (unreleased)" heading.

Description:

Added templates for bug reports and feature requests for Issues on GitHub. I based these templates off of what is being user in the fastruby project: dotenv_validator

I will abide by the [code of conduct](CODE_OF_CONDUCT.md).