### PR TITLE
Find latest compatible version when checking compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,21 +1,21 @@
 # main [(unreleased)](https://github.com/fastruby/next_rails/compare/v1.0.4...main)
 
-- [FEATURE: Try to find the latest **compatible** version of a gem if the latest version is not compatible with the desired Rails version when checking compatibility](https://github.com/fastruby/next_rails/pull/49)
+* [FEATURE: Try to find the latest **compatible** version of a gem if the latest version is not compatible with the desired Rails version when checking compatibility](https://github.com/fastruby/next_rails/pull/49)
 
 # v1.0.5 / 2022-03-29 [(commits)](https://github.com/fastruby/next_rails/compare/v1.0.4...v1.0.5)
 
-- [FEATURE: Initialize the Gemfile.next.lock to avoid major version jumps when used without an initial Gemfile.next.lock](https://github.com/fastruby/next_rails/pull/25)
-- [FEATURE: Drop `actionview` dependency because it is not really used](https://github.com/fastruby/next_rails/pull/26)
-- [BUGFIX: If shitlist path does not exist, create it for the user of the gem](https://github.com/fastruby/next_rails/pull/37)
+* [FEATURE: Initialize the Gemfile.next.lock to avoid major version jumps when used without an initial Gemfile.next.lock](https://github.com/fastruby/next_rails/pull/25)
+* [FEATURE: Drop `actionview` dependency because it is not really used](https://github.com/fastruby/next_rails/pull/26)
+* [BUGFIX: If shitlist path does not exist, create it for the user of the gem](https://github.com/fastruby/next_rails/pull/37)
 
 # v1.0.4 / 2021-04-09 [(commits)](https://github.com/fastruby/next_rails/compare/v1.0.3...v1.0.4)
 
-- [BUGFIX: Fixes issue with `bundle_report` and `actionview`](https://github.com/fastruby/next_rails/pull/22)
+* [BUGFIX: Fixes issue with `bundle_report` and `actionview`](https://github.com/fastruby/next_rails/pull/22)
 
 # v1.0.3 / 2021-04-05 [(commits)](https://github.com/fastruby/next_rails/compare/v1.0.2...v1.0.3)
 
-- [BUGFIX: Update README.md to better document this `ten_years_rails` fork](https://github.com/fastruby/next_rails/pull/11)
-- [BUGFIX: Make ActionView an optional dependency](https://github.com/fastruby/next_rails/pull/6)
+* [BUGFIX: Update README.md to better document this `ten_years_rails` fork](https://github.com/fastruby/next_rails/pull/11)
+* [BUGFIX: Make ActionView an optional dependency](https://github.com/fastruby/next_rails/pull/6)
 
 # v1.0.2 / 2020-01-20
 
@@ -23,4 +23,4 @@
 
 # v1.0.0 / 2019-07-24
 
-- Official Release
+* Official Release

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,23 +1,26 @@
 # main [(unreleased)](https://github.com/fastruby/next_rails/compare/v1.0.4...main)
 
+- [FEATURE: Try to find the latest **compatible** version of a gem if the latest version is not compatible with the desired Rails version when checking compatibility](https://github.com/fastruby/next_rails/pull/49)
+
 # v1.0.5 / 2022-03-29 [(commits)](https://github.com/fastruby/next_rails/compare/v1.0.4...v1.0.5)
 
-* [FEATURE: Initialize the Gemfile.next.lock to avoid major version jumps when used without an initial Gemfile.next.lock](https://github.com/fastruby/next_rails/pull/25)
-* [FEATURE: Drop `actionview` dependency because it is not really used](https://github.com/fastruby/next_rails/pull/26)
-* [BUGFIX: If shitlist path does not exist, create it for the user of the gem](https://github.com/fastruby/next_rails/pull/37)
+- [FEATURE: Initialize the Gemfile.next.lock to avoid major version jumps when used without an initial Gemfile.next.lock](https://github.com/fastruby/next_rails/pull/25)
+- [FEATURE: Drop `actionview` dependency because it is not really used](https://github.com/fastruby/next_rails/pull/26)
+- [BUGFIX: If shitlist path does not exist, create it for the user of the gem](https://github.com/fastruby/next_rails/pull/37)
 
 # v1.0.4 / 2021-04-09 [(commits)](https://github.com/fastruby/next_rails/compare/v1.0.3...v1.0.4)
 
-* [BUGFIX: Fixes issue with `bundle_report` and `actionview`](https://github.com/fastruby/next_rails/pull/22)
+- [BUGFIX: Fixes issue with `bundle_report` and `actionview`](https://github.com/fastruby/next_rails/pull/22)
 
 # v1.0.3 / 2021-04-05 [(commits)](https://github.com/fastruby/next_rails/compare/v1.0.2...v1.0.3)
 
-* [BUGFIX: Update README.md to better document this `ten_years_rails` fork](https://github.com/fastruby/next_rails/pull/11)
-* [BUGFIX: Make ActionView an optional dependency](https://github.com/fastruby/next_rails/pull/6)
+- [BUGFIX: Update README.md to better document this `ten_years_rails` fork](https://github.com/fastruby/next_rails/pull/11)
+- [BUGFIX: Make ActionView an optional dependency](https://github.com/fastruby/next_rails/pull/6)
+
 # v1.0.2 / 2020-01-20
 
 # v1.0.1 / 2019-07-26
 
 # v1.0.0 / 2019-07-24
 
-* Official Release
+- Official Release

--- a/lib/next_rails/gem_info.rb
+++ b/lib/next_rails/gem_info.rb
@@ -28,13 +28,28 @@ module NextRails
       end
     end
 
+    RAILS_GEMS = [
+      "rails",
+      "activemodel",
+      "activerecord",
+      "actionmailer",
+      "actioncable",
+      "actionpack",
+      "actionview",
+      "activejob",
+      "activestorage",
+      "activesupport",
+      "railties",
+    ].freeze
+
     def self.all
       Gem::Specification.each.map do |gem_specification|
         new(gem_specification)
       end
     end
 
-    attr_reader :gem_specification, :version, :name
+    attr_reader :gem_specification, :version, :name, :latest_compatible_version
+
     def initialize(gem_specification)
       @gem_specification = gem_specification
       @version = gem_specification.version
@@ -57,59 +72,69 @@ module NextRails
       version == latest_version.version
     end
 
+    def from_rails?
+      RAILS_GEMS.include?(name)
+    end
+
     def state(rails_version)
       if compatible_with_rails?(rails_version: rails_version)
         :compatible
-      elsif latest_version.compatible_with_rails?(rails_version: rails_version)
-        :latest_compatible
-      elsif latest_version.version == "NOT FOUND"
+      elsif latest_compatible_version.version == "NOT FOUND"
         :no_new_version
+      elsif latest_compatible_version
+        :found_compatible
       else
         :incompatible
       end
     end
 
-    def latest_version
-      @latest_version ||= begin
-        latest_gem_specification = Gem.latest_spec_for(name)
-        if latest_gem_specification
-          GemInfo.new(latest_gem_specification)
-        else
-          NullGemInfo.new
-        end
-      end
-    end
-
-    def compatible_with_rails?(rails_version: Gem::Version.new("5.0"))
+    def compatible_with_rails?(rails_version:)
       unsatisfied_rails_dependencies(rails_version: rails_version).empty?
     end
 
     def unsatisfied_rails_dependencies(rails_version:)
-      rails_dependencies = gem_specification.runtime_dependencies.select {|dependency| rails_gems.include?(dependency.name) }
+      spec_compatible_with_rails?(specification: gem_specification, rails_version: rails_version)
+    end
+
+    def find_latest_compatible(rails_version:)
+      dependency = Gem::Dependency.new(@name)
+      fetcher = Gem::SpecFetcher.new
+
+      # list all available data for released gems
+      list, errors = fetcher.available_specs(:released)
+
+      specs = []
+      # filter only specs for the current gem and older versions
+      list.each do |source, gem_tuples|
+        gem_tuples.each do |gem_tuple|
+          if gem_tuple.name == @name && gem_tuple.version > @version
+            specs << source.fetch_spec(gem_tuple)
+          end
+        end
+      end
+
+      # if nothing is found, consider gem incompatible
+      if specs.empty?
+        @latest_compatible_version = NullGemInfo.new
+        return
+      end
+
+      # if specs are found, look for the first one from that is compatible
+      # with the desired rails version starting from the end
+      specs.reverse.each do |spec|
+        if spec_compatible_with_rails?(specification: spec, rails_version: rails_version).empty?
+          @latest_compatible_version = spec
+          break
+        end
+      end
+    end
+
+    def spec_compatible_with_rails?(specification:, rails_version:)
+      rails_dependencies = specification.runtime_dependencies.select {|dependency| RAILS_GEMS.include?(dependency.name) }
 
       rails_dependencies.reject do |rails_dependency|
         rails_dependency.requirement.satisfied_by?(Gem::Version.new(rails_version))
       end
-    end
-
-    def from_rails?
-      rails_gems.include?(name)
-    end
-
-    private def rails_gems
-      [
-        "rails",
-        "activemodel",
-        "activerecord",
-        "actionmailer",
-        "actioncable",
-        "actionpack",
-        "actionview",
-        "activejob",
-        "activestorage",
-        "activesupport",
-        "railties",
-      ]
     end
   end
 end


### PR DESCRIPTION
- [x] Add an entry to `CHANGELOG.md` that links to this PR under the "main (unreleased)" heading.

**Description:**

This PR changes how we check the compatibility of gems. Currently, if the current version of a gem is not compatible with the desired Rails version, we check if the latest available version of that gem is compatible with Rails.

This is a problem, because the latest version may not be compatible with the desired Rails version, but there might be other versions between the current and the latest that are compatible.

This PR updates the compatibility check to check all versions from the latest to the current until it finds a compatible version.

**How I tested this:**

I really don't know how to add an automated test for this, it relies a lot on external data.

What I did to test this was:
- created a new Rails 4.2.11 app
- changed the version of coffee-rails from 4.1.0 to 4.0.1
- added `next_rail` to the gemfile
- ran `bundle exec bundle_report compatibility --rails-version=5.0.0`

Before this fix:

```
$ bundle exec bundle_report compatibility --rails-version=5.0.0
=> Incompatible with Rails 5.0.0 (with new versions that are compatible):
These gems will need to be upgraded before upgrading to Rails 5.0.0.

rails-dom-testing 1.0.9 - upgrade to 2.0.3

=> Incompatible with Rails 5.0.0 (with no new compatible versions):
These gems will need to be removed or replaced before upgrading to Rails 5.0.0.

coffee-rails 4.0.1 - new version, 5.0.0, is not compatible with Rails 5.0.0

2 gems incompatible with Rails 5.0.0
```

After this fix:

```
$ bundle exec bundle_report compatibility --rails-version=5.0.0
=> Incompatible with Rails 5.0.0 (with new versions that are compatible):
These gems will need to be upgraded before upgrading to Rails 5.0.0.

coffee-rails 4.0.1 - upgrade to 4.2.2
rails-dom-testing 1.0.9 - upgrade to 2.0.3

2 gems incompatible with Rails 5.0.0
```

As expected from the report.

Closes #9 

I will abide by the [code of conduct](https://github.com/fastruby/next_rails/blob/main/CODE_OF_CONDUCT.md).
