### PR TITLE
Support Ruby >= 2.0.0

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby-version: [3.1, 2.7.5, 2.1, 2.0, 1.9]
+        ruby-version: [3.1, 2.7.5, 2.2, 2.1.9, 2.0.0, 1.9.3]
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,14 +7,14 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby-version: [3.1, 2.7.5]
+        ruby-version: [3.1, 2.7.5, 2.1, 2.0, 1.9]
 
     steps:
-    - uses: actions/checkout@v2
-    - name: Set up Ruby ${{ matrix.ruby-version }}
-      uses: ruby/setup-ruby@v1
-      with:
-        ruby-version: ${{ matrix.ruby-version }}
-        bundler-cache: true
-    - name: Run rake task
-      run: bundle exec rake
+      - uses: actions/checkout@v2
+      - name: Set up Ruby ${{ matrix.ruby-version }}
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ${{ matrix.ruby-version }}
+          bundler-cache: true
+      - name: Run rake task
+        run: bundle exec rake

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby-version: [3.1, 2.7.5, 2.2, 2.1.9, 2.0.0, 1.9.3]
+        ruby-version: [3.1, 2.7.5, 2.3, 2.2, 2.1.9, 2.0.0]
 
     steps:
       - uses: actions/checkout@v2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # main [(unreleased)](https://github.com/fastruby/next_rails/compare/v1.0.4...main)
 
+* [FEATURE: Support Ruby versions as old as Ruby 2.0](https://github.com/fastruby/next_rails/pull/54)
+
 * [FEATURE: Try to find the latest **compatible** version of a gem if the latest version is not compatible with the desired Rails version when checking compatibility](https://github.com/fastruby/next_rails/pull/49)
+
 * [FEATURE: Better documentation for contributing and releasing versions of this gem](https://github.com/fastruby/next_rails/pull/53)
 
 * [FEATURE: Added option --version to get the version of the gem being used](https://github.com/fastruby/next_rails/pull/38)

--- a/lib/deprecation_tracker.rb
+++ b/lib/deprecation_tracker.rb
@@ -47,7 +47,11 @@ class DeprecationTracker
   end
 
   # There are two forms of the `warn` method: one for class Kernel and one for instances of Kernel (i.e., every Object)
-  Object.prepend(KernelWarnTracker)
+  if Object.respond_to?(:prepend)
+    Object.prepend(KernelWarnTracker)
+  else
+    Object.extend(KernelWarnTracker)
+  end
 
   # Ruby 2.2 and lower doesn't appear to allow overriding of Kernel.warn using `singleton_class.prepend`.
   if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new("2.3.0")

--- a/lib/deprecation_tracker.rb
+++ b/lib/deprecation_tracker.rb
@@ -202,7 +202,12 @@ class DeprecationTracker
       hash[bucket] = messages.sort
     end
 
-    normalized.reject {|_key, value| value.empty? }.sort_by {|key, _value| key }.to_h
+    # not using `to_h` here to support older ruby versions
+    {}.tap do |h|
+      normalized.reject {|_key, value| value.empty? }.sort_by {|key, _value| key }.each do |k ,v|
+        h[k] = v
+      end
+    end
   end
 
   def read_shitlist

--- a/lib/next_rails/bundle_report.rb
+++ b/lib/next_rails/bundle_report.rb
@@ -15,36 +15,36 @@ module NextRails
 
       incompatible_gems_by_state = incompatible_gems.group_by { |gem| gem.state(rails_version) }
 
-      template = <<~ERB
-        <% if incompatible_gems_by_state[:found_compatible] -%>
-        <%= "=> Incompatible with Rails #{rails_version} (with new versions that are compatible):".white.bold %>
-        <%= "These gems will need to be upgraded before upgrading to Rails #{rails_version}.".italic %>
+      template = <<-ERB
+<% if incompatible_gems_by_state[:found_compatible] -%>
+<%= "=> Incompatible with Rails #{rails_version} (with new versions that are compatible):".white.bold %>
+<%= "These gems will need to be upgraded before upgrading to Rails #{rails_version}.".italic %>
 
-        <% incompatible_gems_by_state[:found_compatible].each do |gem| -%>
-        <%= gem_header(gem) %> - upgrade to <%= gem.latest_compatible_version.version %>
-        <% end -%>
+<% incompatible_gems_by_state[:found_compatible].each do |gem| -%>
+<%= gem_header(gem) %> - upgrade to <%= gem.latest_compatible_version.version %>
+<% end -%>
 
-        <% end -%>
-        <% if incompatible_gems_by_state[:incompatible] -%>
-        <%= "=> Incompatible with Rails #{rails_version} (with no new compatible versions):".white.bold %>
-        <%= "These gems will need to be removed or replaced before upgrading to Rails #{rails_version}.".italic %>
+<% end -%>
+<% if incompatible_gems_by_state[:incompatible] -%>
+<%= "=> Incompatible with Rails #{rails_version} (with no new compatible versions):".white.bold %>
+<%= "These gems will need to be removed or replaced before upgrading to Rails #{rails_version}.".italic %>
 
-        <% incompatible_gems_by_state[:incompatible].each do |gem| -%>
-        <%= gem_header(gem) %> - new version, <%= gem.latest_version.version %>, is not compatible with Rails #{rails_version}
-        <% end -%>
+<% incompatible_gems_by_state[:incompatible].each do |gem| -%>
+<%= gem_header(gem) %> - new version, <%= gem.latest_version.version %>, is not compatible with Rails #{rails_version}
+<% end -%>
 
-        <% end -%>
-        <% if incompatible_gems_by_state[:no_new_version] -%>
-        <%= "=> Incompatible with Rails #{rails_version} (with no new versions):".white.bold %>
-        <%= "These gems will need to be upgraded by us or removed before upgrading to Rails #{rails_version}.".italic %>
-        <%= "This list is likely to contain internal gems, like Cuddlefish.".italic %>
+<% end -%>
+<% if incompatible_gems_by_state[:no_new_version] -%>
+<%= "=> Incompatible with Rails #{rails_version} (with no new versions):".white.bold %>
+<%= "These gems will need to be upgraded by us or removed before upgrading to Rails #{rails_version}.".italic %>
+<%= "This list is likely to contain internal gems, like Cuddlefish.".italic %>
 
-        <% incompatible_gems_by_state[:no_new_version].each do |gem| -%>
-        <%= gem_header(gem) %> - new version not found
-        <% end -%>
+<% incompatible_gems_by_state[:no_new_version].each do |gem| -%>
+<%= gem_header(gem) %> - new version not found
+<% end -%>
 
-        <% end -%>
-        <%= incompatible_gems.length.to_s.red %> gems incompatible with Rails <%= rails_version %>
+<% end -%>
+<%= incompatible_gems.length.to_s.red %> gems incompatible with Rails <%= rails_version %>
       ERB
 
       puts ERB.new(template, nil, "-").result(binding)
@@ -104,15 +104,15 @@ module NextRails
       out_of_date_gems.each do |_gem|
         header = "#{_gem.name} #{_gem.version}"
 
-        puts <<~MESSAGE
-          #{header.bold.white}: released #{_gem.age} (latest version, #{_gem.latest_version.version}, released #{_gem.latest_version.age})
+        puts <<-MESSAGE
+#{header.bold.white}: released #{_gem.age} (latest version, #{_gem.latest_version.version}, released #{_gem.latest_version.age})
         MESSAGE
       end
 
       puts ""
-      puts <<~MESSAGE
-        #{"#{sourced_from_git.count}".yellow} gems are sourced from git
-        #{"#{out_of_date_gems.length}".red} of the #{gems.count} gems are out-of-date (#{percentage_out_of_date}%)
+      puts <<-MESSAGE
+#{"#{sourced_from_git.count}".yellow} gems are sourced from git
+#{"#{out_of_date_gems.length}".red} of the #{gems.count} gems are out-of-date (#{percentage_out_of_date}%)
       MESSAGE
     end
   end

--- a/lib/next_rails/bundle_report.rb
+++ b/lib/next_rails/bundle_report.rb
@@ -6,7 +6,7 @@ require "net/http"
 
 module NextRails
   class BundleReport
-    def self.compatibility(rails_version:, include_rails_gems:)
+    def self.compatibility(rails_version: nil, include_rails_gems: nil)
       incompatible_gems = NextRails::GemInfo.all.reject do |gem|
         gem.compatible_with_rails?(rails_version: rails_version) || (!include_rails_gems && gem.from_rails?)
       end.sort_by { |gem| gem.name }

--- a/lib/next_rails/gem_info.rb
+++ b/lib/next_rails/gem_info.rb
@@ -88,15 +88,15 @@ module NextRails
       end
     end
 
-    def compatible_with_rails?(rails_version:)
+    def compatible_with_rails?(rails_version: nil)
       unsatisfied_rails_dependencies(rails_version: rails_version).empty?
     end
 
-    def unsatisfied_rails_dependencies(rails_version:)
+    def unsatisfied_rails_dependencies(rails_version: nil)
       spec_compatible_with_rails?(specification: gem_specification, rails_version: rails_version)
     end
 
-    def find_latest_compatible(rails_version:)
+    def find_latest_compatible(rails_version: nil)
       dependency = Gem::Dependency.new(@name)
       fetcher = Gem::SpecFetcher.new
 
@@ -129,7 +129,7 @@ module NextRails
       end
     end
 
-    def spec_compatible_with_rails?(specification:, rails_version:)
+    def spec_compatible_with_rails?(specification: nil, rails_version: nil)
       rails_dependencies = specification.runtime_dependencies.select {|dependency| RAILS_GEMS.include?(dependency.name) }
 
       rails_dependencies.reject do |rails_dependency|

--- a/next_rails.gemspec
+++ b/next_rails.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |spec|
   spec.homepage     = "https://github.com/fastruby/next_rails"
   spec.license       = "MIT"
 
-  spec.required_ruby_version = ">= 2.3.0"
+  spec.required_ruby_version = ">= 0"
 
   spec.files         = `git ls-files -z`.split("\x0").reject do |f|
     f.match(%r{^(test|spec|features)/})

--- a/next_rails.gemspec
+++ b/next_rails.gemspec
@@ -29,5 +29,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rspec", "~> 3.0"
   spec.add_development_dependency "simplecov", "~> 0.17.1"
   spec.add_development_dependency "timecop", "~> 0.9.1"
+  spec.add_development_dependency "rexml", "3.1.7.3"
   spec.add_development_dependency "webmock"
 end

--- a/next_rails.gemspec
+++ b/next_rails.gemspec
@@ -29,6 +29,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rspec", "~> 3.0"
   spec.add_development_dependency "simplecov", "~> 0.17.1"
   spec.add_development_dependency "timecop", "~> 0.9.1"
-  spec.add_development_dependency "rexml", "3.1.7.3"
+  spec.add_development_dependency "rexml", "3.1.7.3" # limited on purpose, new versions don't work with old rubies
   spec.add_development_dependency "webmock"
 end

--- a/next_rails.gemspec
+++ b/next_rails.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency "colorize", ">= 0.8.1"
   spec.add_development_dependency "bundler", ">= 1.16", "< 3.0"
-  spec.add_development_dependency "rake", "~> 13.0"
+  spec.add_development_dependency "rake"
   spec.add_development_dependency "rspec", "~> 3.0"
   spec.add_development_dependency "simplecov", "~> 0.17.1"
   spec.add_development_dependency "timecop", "~> 0.9.1"

--- a/next_rails.gemspec
+++ b/next_rails.gemspec
@@ -30,5 +30,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "simplecov", "~> 0.17.1"
   spec.add_development_dependency "timecop", "~> 0.9.1"
   spec.add_development_dependency "rexml", "3.1.7.3" # limited on purpose, new versions don't work with old rubies
-  spec.add_development_dependency "webmock"
+  spec.add_development_dependency "webmock", "3.14.0" # limited on purpose, new versions don't work with old rubies
 end

--- a/next_rails.gemspec
+++ b/next_rails.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |spec|
   spec.homepage     = "https://github.com/fastruby/next_rails"
   spec.license       = "MIT"
 
-  spec.required_ruby_version = ">= 0"
+  spec.required_ruby_version = ">= 2.0"
 
   spec.files         = `git ls-files -z`.split("\x0").reject do |f|
     f.match(%r{^(test|spec|features)/})


### PR DESCRIPTION
This PR adds support for older Ruby 2 versions.

Things I changed:
- added explicit default values for keyword arguments (implicit values not supported in older rubies)
- limit `rexml` version, newer versions use implicit default values for keywords arguments (related to the previous change)
- use the `<<-` heredoc syntax instead of `<<~`, the `~` version didn't exist in older rubies (since what it does is remove the indentation, I removed the indentation in the code instead)
- use `Object.extend` if `Object.prepend` is not a valid method, it was added in Ruby 2.1.10 https://apidock.com/ruby/v2_1_10/Module/prepend
- replace a call to `Array#to_h`, since that method was added in Ruby 2.1.10 https://apidock.com/ruby/v2_1_10/Array/to_h
- configured the github actions to run the tests with more Ruby versions

I tried to add support for ruby 1.9.3 but it requires rewriting methods because the ruby2 keyword arguments syntax is not valid. Adding this for reference https://bugs.ruby-lang.org/issues/7664