### PR TITLE
Add release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,53 @@
+name: release
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [ main ]
+
+jobs:
+  release-release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Update Release PR
+        uses: google-github-actions/release-please-action@v3
+        id: release
+        with:
+          release-type: ruby
+          package-name: next_rails
+          version-file: "lib/next_rails/version.rb"
+          changelog-types: '[{"type":"feat","section":"Features","hidden":false}, {"type":"fix","section":"Bug Fixes","hidden":false}, {"type":"chore", "section":"Miscellaneous","hidden":false}]'
+      - name: Checkout
+        uses: actions/checkout@v3
+        if: ${{ steps.release.outputs.release_created }}
+      - name: Set Up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          bundle-cache: true
+        if: ${{ steps.release.outputs.release_created }}
+      - name: Bundle Install
+        run: bundle install
+        if: ${{ steps.release.outputs.release_created }}
+      - name: Publish to GitHub
+        run: |
+          mkdir -p $HOME/.gem
+          touch $HOME/.gem/credentials
+          chmod 0600 $HOME/.gem/credentials
+          printf -- "---\n:github: ${GEM_HOST_API_KEY}\n" > $HOME/.gem/credentials
+          gem build *.gemspec
+          gem push --KEY github --host https://rubygems.pkg.github.com/${OWNER} *.gem
+        env:
+          GEM_HOST_API_KEY: "Bearer ${{secrets.GITHUB_TOKEN}}"
+          OWNER: ${{ github.repository_owner }}
+        if: ${{ steps.release.outputs.release_created }}
+      - name: Publish to RubyGems
+        run: |
+          mkdir -p $HOME/.gem
+          touch $HOME/.gem/credentials
+          chmod 0600 $HOME/.gem/credentials
+          printf -- "---\n:rubygems_api_key: ${GEM_HOST_API_KEY}\n" > $HOME/.gem/credentials
+          gem build *.gemspec
+          gem push *.gem
+        env:
+          GEM_HOST_API_KEY: "${{ secrets.RUBYGEMS_AUTH_TOKEN }}"
+        if: ${{ steps.release.outputs.release_created }}


### PR DESCRIPTION
Following [conventionalcommits](https://www.conventionalcommits.org/en/v1.0.0/#summary)
we will be able to release this gem into GitHub and RubyGems. If you are
not pretty sure how to write your commits here is a
[guide](https://github.com/googleapis/release-please#how-should-i-write-my-commits).

- [x] Add release packages in GitHub (.zip file)
- [x] Update release version in RubyGems.
- [x] Add the commit's title and body into the `CHANGELOG` file automatically.
- [x] Will open a PR with the proposal release, (don't release anything by itself, you decide when you want to release :muscle:).

Related Links:
- https://www.conventionalcommits.org/en/v1.0.0/#summary
- https://github.com/googleapis/release-please#release-please
- https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-ruby#publishing-gems