### PR TITLE
update CHANGELOG with info tagged under correct released versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,10 @@
 # main [(unreleased)](https://github.com/fastruby/next_rails/compare/v1.0.4...main)
 
-* [FEATURE: Try to find the latest **compatible** version of a gem if the latest version is not compatible with the desired Rails version when checking compatibility](https://github.com/fastruby/next_rails/pull/49)
 * [FEATURE: Better documentation for contributing and releasing versions of this gem](https://github.com/fastruby/next_rails/pull/53)
+
+# v1.1.0 / 2022-06-30 [(commits)](https://github.com/fastruby/next_rails/compare/v1.0.5...v1.1.0)
+
+* [FEATURE: Try to find the latest **compatible** version of a gem if the latest version is not compatible with the desired Rails version when checking compatibility](https://github.com/fastruby/next_rails/pull/49)
 
 * [FEATURE: Added option --version to get the version of the gem being used](https://github.com/fastruby/next_rails/pull/38)
 


### PR DESCRIPTION
Description:

The current CHANGELOG  does not have an entry for the last released version of the gem i.e 1.1.0.
All the changes in 1.1.0 are mentioned under the `# main [(unreleased)]` heading which is incorrect.

So, I have added an entry for 1.1.0 and put everything that belonged in that release under it and added a 
`# main [(unreleased)]` at the top for future changes.

I will abide by the [code of conduct](https://github.com/fastruby/next_rails/blob/main/CODE_OF_CONDUCT.md).
