### PR TITLE
Fix for up_to_date? method

### DIFF
--- a/lib/next_rails/gem_info.rb
+++ b/lib/next_rails/gem_info.rb
@@ -88,6 +88,15 @@ module NextRails
       end
     end
 
+    def latest_version
+      latest_gem_specification = Gem.latest_spec_for(name)
+      return NullGemInfo.new unless latest_gem_specification
+
+      GemInfo.new(latest_gem_specification)
+    rescue
+      NullGemInfo.new
+    end
+
     def compatible_with_rails?(rails_version:)
       unsatisfied_rails_dependencies(rails_version: rails_version).empty?
     end

--- a/lib/next_rails/gem_info.rb
+++ b/lib/next_rails/gem_info.rb
@@ -97,7 +97,7 @@ module NextRails
       NullGemInfo.new
     end
 
-    def compatible_with_rails?(rails_version:)
+    def compatible_with_rails?(rails_version: nil)
       unsatisfied_rails_dependencies(rails_version: rails_version).empty?
     end
 

--- a/spec/ten_years_rails/gem_info_spec.rb
+++ b/spec/ten_years_rails/gem_info_spec.rb
@@ -7,6 +7,7 @@ RSpec.describe NextRails::GemInfo do
   let(:spec) do
     Gem::Specification.new do |s|
       s.date = release_date
+      s.version = "1.0.0"
     end
   end
 
@@ -23,6 +24,13 @@ RSpec.describe NextRails::GemInfo do
 
     it "returns a date" do
       expect(subject.age).to eq(result)
+    end
+  end
+
+  describe "#up_to_date?" do
+    it "is up to date" do
+      allow(Gem).to receive(:latest_spec_for).and_return(spec)
+      expect(subject.up_to_date?).to be_truthy
     end
   end
 end


### PR DESCRIPTION
`bundle_report outdated` is currently failing with "undefined local variable or method `latest_version'".
We need to define latest_version method to filter out up-to-date gems.
