### PR TITLE
[OSS-64] Add templates for bug report, feature request and pull request

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -6,46 +6,32 @@ labels: bug
 assignees: ""
 ---
 
-**IMPORTANT: please make sure you ask yourself all intro questions and fill all sections of the template.**
+<!--- Before creating a bug report, please, answer the following questions -->
+<!--- Did you check the documentation for answers? -->
+<!--- Did you make sure that this bug has not already been reported? -->
 
-**Before we start...:**
+## Expected Behavior
+<!--- Tell us what should happen -->
+<!--- For example: When I [do X], it should [produce Y] -->
 
-- [ ] I checked the documentation and found no answer
-- [ ] I checked to make sure that this issue has not already been filed
-- [ ] I'm reporting the issue to the correct repository (for multi-repository projects)
+## Actual Behavior
+<!--- Tell us what happens instead -->
+<!--- For example: When I [did X], it [produced Y] -->
 
-**Version, Branch, or Commit:**
+## Possible Fix
+<!--- Optionally suggest a fix or work around -->
 
-What branch/commit/version of "next_rails" you are using?
+## To Reproduce
+<!--- Optionally provide a link to a live example -->
 
-**Expected behavior:**
+<!--- Otherwise, please provide a set of reproduction steps -->
+1.
+2.
+3.
+4.
 
-Please include a detailed description of the behavior you were expecting when you encountered this issue.
-
-**Actual behavior:**
-
-Please include a detailed description of the actual behavior of the application.
-
-**Steps to reproduce:**
-
-How do I achieve this behavior? Use the following format to provide a step-by-step guide:
-
-1. Step 1: ...
-2. Step 2: ...
-
-**Context and environment:**
-
-Provide any relevant information about your setup (Customize the list accordingly based on what info is relevant to this project)
-
-1. Version of the software the issue is being opened for.
-2. Operating System
-3. Operating System version
-4. Ruby version
-
-_Delete any information that is not relevant._
-
-**Logs**
-
-Include relevant log snippets or files here.
+## Additional Information
+<!--- Include any relevant details about your environment (branch, browser, OS) -->
+<!--- and the bug (screenshots, logs, etc) -->
 
 **I will abide by the [code of conduct](https://github.com/fastruby/next_rails/blob/main/CODE_OF_CONDUCT.md)**

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -6,35 +6,18 @@ labels: enhancement
 assignees: ""
 ---
 
-**IMPORTANT: please make sure you ask yourself all intro questions and fill all sections of the template.**
+<!--- Before creating a feature request, please, answer the following questions -->
+<!--- Did you check the documentation for this feature? -->
+<!--- Did you make sure that this feature has not already been requested? -->
 
-**Before we start...:**
+## Description
+<!--- Provide a description of the change or addition you are proposing -->
 
-- [ ] I checked the documentation and didn't find this feature
-- [ ] I checked to make sure that this feature has not already been requested
+## Possible Implementation
+<!--- Optionally suggest an idea to implement or a workaround to fix the issue -->
 
-**Branch/Commit:**
-
-Inform what branch/commit/version of "next_rails" you are using.
-
-**Describe the feature:**
-
-Please include a detailed description of the feature you are requesting and any detail on it’s expected behavior.
-
-> **As a \<role name\>** > **I do \<something\>** > **And then I do \<another action\>** > **And I see \<some result\>**
-
-**Problem:**
-
-Please include a detailed description of the problem this feature would solve.
-
-> **As a \<role name\>** > **I want to \<do something\>** > **So that I can achieve a \<goal\>**
-
-**Mockups:**
-
-Include any mockup idea related to the requested feature if it applies.
-
-**Resources:**
-
-If you have resources related to the implementation or research for this feature, add them here.
+## Resources:
+<!--- If you have resources related to the implementation or research for this feature, add them here. -->
+<!--- If possible, include any mockup ideas related to the requested feature. -->
 
 **I will abide by the [code of conduct](https://github.com/fastruby/next_rails/blob/main/CODE_OF_CONDUCT.md)**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 # main [(unreleased)](https://github.com/fastruby/next_rails/compare/v1.0.4...main)
+* [CHORE: Added updated templates for bug fixes, feature requests and pull requests](https://github.com/fastruby/next_rails/pull/64) as per [this RFC](https://github.com/fastruby/RFCs/blob/main/2021-10-13-github-templates.md)
 
 * [FEATURE: Better documentation for contributing and releasing versions of this gem](https://github.com/fastruby/next_rails/pull/53)
 

--- a/pull_request_template.md
+++ b/pull_request_template.md
@@ -1,9 +1,15 @@
-**IMPORTANT**: Please read the README before submitting pull requests for this project. Additionally, if your PR closes any open GitHub issues, make sure you include Closes #XXXX in your comment or use the option on the PR's sidebar to add related issues to auto-close the issue that your PR fixes.
+## Description
+<!--- Describe your changes in detail -->
 
-- [ ] Add an entry to `CHANGELOG.md` that links to this PR under the "main (unreleased)" heading.
+## Motivation and Context
+<!--- Why is this change required? What problem does it solve? -->
+<!--- If it fixes an open issue, please link to the issue here. -->
 
-Description:
+## How Has This Been Tested?
+<!--- Include any relevant details about your testing environment and the steps you followed -->
+<!--- For example: I am using [Safari|Firefox|Chrome] then I visit [the users path] -->
 
-Please include a summary of the change and which issue is fixed or which feature is introduced. If changes to the behavior are made, clearly describe what changes.
+## Screenshots:
+<!-- Add screenshots (applicable to any UI changes) -->
 
-I will abide by the [code of conduct](https://github.com/fastruby/next_rails/blob/main/CODE_OF_CONDUCT.md).
+**I will abide by the [code of conduct](https://github.com/fastruby/next_rails/blob/main/CODE_OF_CONDUCT.md)**


### PR DESCRIPTION
- [x] Add an entry to `CHANGELOG.md` that links to this PR under the "main (unreleased)" heading.

Description:

Simply updates our templates for bug fixes, feature requests and pull requests, as agreed upon in [this RFC](https://github.com/fastruby/RFCs/blob/main/2021-10-13-github-templates.md)

I will abide by the [code of conduct](https://github.com/fastruby/next_rails/blob/main/CODE_OF_CONDUCT.md).
