### PR TITLE
SimpleCov must be loaded as the very first thing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # main [(unreleased)](https://github.com/fastruby/next_rails/compare/v1.0.4...main)
 
+* [BUGFIX: SimpleCov was not reporting accurately due to a bug in the spec helper code](https://github.com/fastruby/next_rails/pull/66)
 * [FEATURE: Better documentation for contributing and releasing versions of this gem](https://github.com/fastruby/next_rails/pull/53)
 
 # v1.1.0 / 2022-06-30 [(commits)](https://github.com/fastruby/next_rails/compare/v1.0.5...v1.1.0)

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,8 +1,3 @@
-require "bundler/setup"
-require "next_rails"
-
-require 'webmock/rspec'
-WebMock.disable_net_connect!(allow_localhost: true)
 
 if ENV['COVERAGE'] == 'true'
   require 'simplecov'
@@ -22,6 +17,12 @@ if ENV['COVERAGE'] == 'true'
     track_files "lib/**/*.rb"
   end
 end
+
+require "bundler/setup"
+require "next_rails"
+
+require 'webmock/rspec'
+WebMock.disable_net_connect!(allow_localhost: true)
 
 RSpec.configure do |config|
   # Enable flags like --only-failures and --next-failure


### PR DESCRIPTION
- [x] Add an entry to `CHANGELOG.md` that links to this PR under the "main (unreleased)" heading.

Description:

SimpleCov must be loaded as the very first thing

If not, coverage reporting and calculation will be inaccurate. This is a known gotcha with SimpleCov.

Fixes https://github.com/fastruby/next_rails/issues/65

I will abide by the [code of conduct](https://github.com/fastruby/next_rails/blob/main/CODE_OF_CONDUCT.md).
