### PR TITLE
added back the latest_version method

### DIFF
--- a/lib/next_rails/gem_info.rb
+++ b/lib/next_rails/gem_info.rb
@@ -88,6 +88,17 @@ module NextRails
       end
     end
 
+    def latest_version
+      @latest_version ||= begin
+        latest_gem_specification = Gem.latest_spec_for(name)
+        if latest_gem_specification
+          GemInfo.new(latest_gem_specification)
+        else
+          NullGemInfo.new
+        end
+      end
+    end
+
     def compatible_with_rails?(rails_version: nil)
       unsatisfied_rails_dependencies(rails_version: rails_version).empty?
     end


### PR DESCRIPTION
Description:

Closes #70 and #72. 

I noticed that these issues are arising because a method `def latest_version` was removed.
It was removed in this commit https://github.com/fastruby/next_rails/commit/40590042e11978e5765049ab293b3114b490324b

but I can still find instances of this method being used in the code.
Hence I have added the method back.