### PR TITLE
Issue latest version method

### DIFF
--- a/lib/next_rails/gem_info.rb
+++ b/lib/next_rails/gem_info.rb
@@ -88,6 +88,17 @@ module NextRails
       end
     end
 
+    def latest_version
+      @latest_version ||= begin
+        latest_gem_specification = Gem.latest_spec_for(name)
+        if latest_gem_specification
+          GemInfo.new(latest_gem_specification)
+        else
+          NullGemInfo.new
+        end
+      end
+    end
+
     def compatible_with_rails?(rails_version: nil)
       unsatisfied_rails_dependencies(rails_version: rails_version).empty?
     end

--- a/spec/ten_years_rails/gem_info_spec.rb
+++ b/spec/ten_years_rails/gem_info_spec.rb
@@ -25,4 +25,11 @@ RSpec.describe NextRails::GemInfo do
       expect(subject.age).to eq(result)
     end
   end
+
+  describe "#up_to_date?" do
+    it "is up to date" do
+      allow(Gem).to receive(:latest_spec_for).and_return(spec)
+      expect(subject.up_to_date?).to be_truthy
+    end
+  end
 end


### PR DESCRIPTION
Description:

Closes #70 and #72. 

I noticed that these issues are arising because a method `def latest_version` was removed.
It was removed in this commit https://github.com/fastruby/next_rails/commit/40590042e11978e5765049ab293b3114b490324b

but I can still find instances of this method being used in the code.
Hence I have added the method back.


This PR is duplicate of #62 , but due to inactivity in the original PR as it needs some merge conflicts, I am raising this, so we can merge and roll out the fix as the current versions have breakages.