### PR TITLE
Fix bundle report compatibility error

### DIFF
--- a/lib/next_rails/gem_info.rb
+++ b/lib/next_rails/gem_info.rb
@@ -79,7 +79,7 @@ module NextRails
     def state(rails_version)
       if compatible_with_rails?(rails_version: rails_version)
         :compatible
-      elsif latest_compatible_version.version == "NOT FOUND"
+      elsif latest_compatible_version&.version == "NOT FOUND"
         :no_new_version
       elsif latest_compatible_version
         :found_compatible

--- a/lib/next_rails/gem_info.rb
+++ b/lib/next_rails/gem_info.rb
@@ -77,14 +77,14 @@ module NextRails
     end
 
     def state(rails_version)
-      return :compatible if compatible_with_rails?(rails_version: rails_version)
-
-      if latest_compatible_version.nil?
-        :incompatible
-      elsif latest_compatible_version.version == "NOT FOUND"
+      if compatible_with_rails?(rails_version: rails_version)
+        :compatible
+      elsif latest_compatible_version && latest_compatible_version.version == "NOT FOUND"
         :no_new_version
-      else
+      elsif latest_compatible_version
         :found_compatible
+      else
+        :incompatible
       end
     end
 

--- a/lib/next_rails/gem_info.rb
+++ b/lib/next_rails/gem_info.rb
@@ -77,14 +77,14 @@ module NextRails
     end
 
     def state(rails_version)
-      if compatible_with_rails?(rails_version: rails_version)
-        :compatible
-      elsif latest_compatible_version&.version == "NOT FOUND"
-        :no_new_version
-      elsif latest_compatible_version
-        :found_compatible
-      else
+      return :compatible if compatible_with_rails?(rails_version: rails_version)
+
+      if latest_compatible_version.nil?
         :incompatible
+      elsif latest_compatible_version.version == "NOT FOUND"
+        :no_new_version
+      else
+        :found_compatible
       end
     end
 

--- a/spec/next_rails/gem_info_spec.rb
+++ b/spec/next_rails/gem_info_spec.rb
@@ -1,0 +1,36 @@
+require_relative ".././spec_helper"
+require_relative "../../lib/next_rails/gem_info"
+
+RSpec.describe NextRails::GemInfo do
+  describe "#state" do
+    let(:mock_gem) { Struct.new(:name, :version, :runtime_dependencies) }
+    let(:mocked_dependency) { Struct.new(:name, :requirement) }
+    it "returns :incompatible if gem specifies a rails dependency but no compatible version is found" do
+
+      mocked_dependency_requirement = double("requirement")
+      allow(mocked_dependency_requirement).to receive(:satisfied_by?).and_return(false)
+      runtime_deps = [mocked_dependency.new("rails", mocked_dependency_requirement)]
+      incompatible_gem = mock_gem.new('incompatible', '0.0.1', runtime_deps)
+      rails_version = "7.0.0"
+      gem_info = NextRails::GemInfo.new(incompatible_gem)
+
+      expect(gem_info.state(rails_version)).to eq(:incompatible)
+    end
+
+  end
+
+  describe "#find_latest_compatible" do
+    let(:mock_gem) { Struct.new(:name, :version) }
+    it "sets latest_compatible_version to NullGem if no specs are found" do
+      fetcher_double = double("spec_fetcher")
+      allow(fetcher_double).to receive(:available_specs).and_return([[],[]])
+      allow(Gem::SpecFetcher).to receive(:new).and_return(fetcher_double)
+      gem = mock_gem.new('gem_name', "0.0.1")
+
+      gem_info = NextRails::GemInfo.new(gem)
+      gem_info.find_latest_compatible
+      expect(gem_info.latest_compatible_version).to be_a(NextRails::GemInfo::NullGemInfo)
+    end
+
+  end
+end

--- a/spec/next_rails/gem_info_spec.rb
+++ b/spec/next_rails/gem_info_spec.rb
@@ -6,15 +6,35 @@ RSpec.describe NextRails::GemInfo do
     let(:mock_gem) { Struct.new(:name, :version, :runtime_dependencies) }
     let(:mocked_dependency) { Struct.new(:name, :requirement) }
     it "returns :incompatible if gem specifies a rails dependency but no compatible version is found" do
-
+      # set up a mock gem with with a rails dependency that is unsatisfied by the version given
       mocked_dependency_requirement = double("requirement")
       allow(mocked_dependency_requirement).to receive(:satisfied_by?).and_return(false)
       runtime_deps = [mocked_dependency.new("rails", mocked_dependency_requirement)]
       incompatible_gem = mock_gem.new('incompatible', '0.0.1', runtime_deps)
+
       rails_version = "7.0.0"
       gem_info = NextRails::GemInfo.new(incompatible_gem)
 
       expect(gem_info.state(rails_version)).to eq(:incompatible)
+    end
+
+    it "returns :no_new_version if a gem specifies an unsatisfied rails dependency and no other specs are returned" do
+      # set up a mock gem with with a rails dependency that is unsatisfied by the version given
+      mocked_dependency_requirement = double("requirement")
+      allow(mocked_dependency_requirement).to receive(:satisfied_by?).and_return(false)
+      runtime_deps = [mocked_dependency.new("rails", mocked_dependency_requirement)]
+      incompatible_gem = mock_gem.new('incompatible', '0.0.1', runtime_deps)
+
+      # Set up a mock SpecFetcher to return an empty list
+      fetcher_double = double("spec_fetcher")
+      allow(fetcher_double).to receive(:available_specs).and_return([[],[]])
+      allow(Gem::SpecFetcher).to receive(:new).and_return(fetcher_double)
+
+      rails_version = "7.0.0"
+      gem_info = NextRails::GemInfo.new(incompatible_gem)
+      gem_info.find_latest_compatible
+
+      expect(gem_info.state(rails_version)).to eq(:no_new_version)
     end
 
   end
@@ -22,10 +42,12 @@ RSpec.describe NextRails::GemInfo do
   describe "#find_latest_compatible" do
     let(:mock_gem) { Struct.new(:name, :version) }
     it "sets latest_compatible_version to NullGem if no specs are found" do
+      gem = mock_gem.new('gem_name', "0.0.1")
+
+      # Set up a mock SpecFetcher to return an empty list
       fetcher_double = double("spec_fetcher")
       allow(fetcher_double).to receive(:available_specs).and_return([[],[]])
       allow(Gem::SpecFetcher).to receive(:new).and_return(fetcher_double)
-      gem = mock_gem.new('gem_name', "0.0.1")
 
       gem_info = NextRails::GemInfo.new(gem)
       gem_info.find_latest_compatible


### PR DESCRIPTION
## Description
- Adds use of safe access operator in `GemInfo#state` conditional expression

## Motivation and Context
- This fix is related to issue [#77](https://github.com/fastruby/next_rails/issues/77)
- Without this safe access operator the `else` part of this condition is never reached when `@latest_compatible_version` is `nil`. 

I will say I'm not completely clear on the logic in `#find_latest_compatible`. I don't know enough about the shape of the spec objects and the edge cases surrounding them. It appears to me that the error state is caused when there are specs found by the `Gem::SpecFetcher` but none of them are compatible with the version of Rails given. This will execute `#find_latest_compatible` but never set the `@latest_compatible_version` instance variable. It's a bit confusing as there is a null object pattern being used along with a nil state and it's hard to parse the meaning behind each without more context.

I'd be happy to adjust the solution if this is more of a band-aid than a true fix.


## How Has This Been Tested?
- Running the test suite locally


**I will abide by the [code of conduct](https://github.com/fastruby/next_rails/blob/main/CODE_OF_CONDUCT.md)**
