### PR TITLE
Adds support to print info for multiple files.

### DIFF
--- a/exe/deprecations
+++ b/exe/deprecations
@@ -37,6 +37,13 @@ def print_info(deprecation_warnings, opts = {})
   end
 end
 
+def extract_deprecations(path, pattern)
+  JSON.parse(File.read(path)).each_with_object({}) do |(test_file, messages), hash|
+    filtered_messages = messages.select {|message| message.match(pattern) }
+    hash[test_file] = filtered_messages if !filtered_messages.empty?
+  end
+end
+
 options = {}
 option_parser = OptionParser.new do |opts|
   opts.banner = <<-MESSAGE
@@ -90,9 +97,6 @@ path = options[:next] ? "spec/support/deprecation_warning.next.shitlist.json" : 
 pattern_string = options.fetch(:pattern, ".+")
 pattern = /#{pattern_string}/
 
-deprecation_warnings = JSON.parse(File.read(path)).each_with_object({}) do |(test_file, messages), hash|
-  filtered_messages = messages.select {|message| message.match(pattern) }
-  hash[test_file] = filtered_messages if !filtered_messages.empty?
 end
 
 if deprecation_warnings.empty?

--- a/exe/deprecations
+++ b/exe/deprecations
@@ -83,6 +83,10 @@ option_parser = OptionParser.new do |opts|
     options[:verbose] = true
   end
 
+  opts.on("--path PATH_OR_FILE_GLOB", "Path to deprecation shitlist or glob for multiple files") do |path|
+    options[:path] = path
+  end
+
   opts.on_tail("-h", "--help", "Prints this help") do
     puts opts
     exit
@@ -92,7 +96,11 @@ end
 option_parser.parse!
 
 options[:mode] = ARGV.last
-path = options[:next] ? "spec/support/deprecation_warning.next.shitlist.json" : "spec/support/deprecation_warning.shitlist.json"
+path = if options[:path]
+  options[:path]
+else
+  options[:next] ? "spec/support/deprecation_warning.next.shitlist.json" : "spec/support/deprecation_warning.shitlist.json"
+end
 
 pattern_string = options.fetch(:pattern, ".+")
 pattern = /#{pattern_string}/

--- a/exe/deprecations
+++ b/exe/deprecations
@@ -105,6 +105,14 @@ end
 pattern_string = options.fetch(:pattern, ".+")
 pattern = /#{pattern_string}/
 
+file_paths = Dir.glob(path)
+
+if file_paths.empty?
+  abort "No files found with name #{options[:path]}"
+  exit 2
+else
+  deprecation_warnings = file_paths.map { |path| extract_deprecations(path, pattern) }
+                                   .inject(:merge)
 end
 
 if deprecation_warnings.empty?


### PR DESCRIPTION
## Description
This is a bit of a 2 for 1:
1. It adds a new option, `--path`, so that we can provide a custom path to our deprecation files.
2. With this option we can also give the `deprecations` command a file glob. That way it will print out information on the deprecation warnings present in all the files that match that glob.

And that's basically it.

## Motivation and Context
The motivation is given on the issue it fixes. Fixes #3.

## How Has This Been Tested?
Manually on the command line since the info command is entirely contained in the `exe/deprecations` script.

**I will abide by the [code of conduct](https://github.com/fastruby/next_rails/blob/main/CODE_OF_CONDUCT.md)**
