### PR TITLE
Test next_rails with more versions of ruby

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby-version: [3.1, 2.7.5, 2.3, 2.2, 2.1.9, 2.0.0]
+        ruby-version: [3.2, 3.1, 3.0, 2.7, 2.6, 2.5, 2.4, 2.3, 2.2, 2.1, 2.0.0]
 
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
## Description

We want to test with all the rubies since 2.0

## Motivation and Context

We need to make sure this lib works with all the rubies we have encountered since 2.0 came out

## How Has This Been Tested?

GitHub Actions CI 

**I will abide by the [code of conduct](https://github.com/fastruby/next_rails/blob/main/CODE_OF_CONDUCT.md)**
