### PR TITLE
Update deprecation warning file name

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ deprecations run
 deprecations --help # For more options and examples
 ```
 
-Right now, the path to the shitlist is hardcoded so make sure you store yours at `spec/support/deprecations.shitlist.json`.
+Right now, the path to the shitlist is hardcoded so make sure you store yours at `spec/support/deprecation_warning.shitlist.json`.
 
 #### `next_rails` command
 


### PR DESCRIPTION
## Description
Following the README.md it says we should have a `deprecations.shitlist.json` file but it actually needs a `deprecation_warning.shitlist.json` file name.

## Motivation and Context
Make the README match the actual file name.

## How Has This Been Tested?
I tested on a local project changing the name to `deprecation_warning.shitlist.json` and it works.

## Screenshots:

Error trace
```bash
root@5f3850ba4310:/app# deprecations info
Traceback (most recent call last):
        3: from /usr/local/bundle/bin/deprecations:23:in `<main>'
        2: from /usr/local/bundle/bin/deprecations:23:in `load'
        1: from /usr/local/bundle/gems/next_rails-1.2.1/exe/deprecations:93:in `<top (required)>'
/usr/local/bundle/gems/next_rails-1.2.1/exe/deprecations:93:in `read': No such file or directory @ rb_sysopen - spec/support/deprecation_warning.shitlist.json (Errno::ENOENT)
```

**I will abide by the [code of conduct](https://github.com/fastruby/next_rails/blob/main/CODE_OF_CONDUCT.md)**
