### PR TITLE
Ignore actionmailbox and actiontext rails gems from bundle report

### DIFF
--- a/lib/next_rails/gem_info.rb
+++ b/lib/next_rails/gem_info.rb
@@ -39,6 +39,8 @@ module NextRails
       "activejob",
       "activestorage",
       "activesupport",
+      "actionmailbox",
+      "actiontext",
       "railties",
     ].freeze
 


### PR DESCRIPTION
This PR fixes #89

Output on a test project I was using with Rails 6

Before:
```
bundle_report compatibility --rails-version=7.0 
=> Incompatible with Rails 7.0 (with new versions that are compatible):
These gems will need to be upgraded before upgrading to Rails 7.0.

actionmailbox 6.0.4 - upgrade to 7.0.0
actiontext 6.0.4 - upgrade to 7.0.0
dotenv-rails 2.7.5 - upgrade to 2.8.1
ombu_labs-hubspot 0.1.0 (loaded from git) - upgrade to 0.1.1
ombu_labs-notifications 0.1.0 (loaded from git) - upgrade to 0.1.2

5 gems incompatible with Rails 7.0
```

After:
```
bundle_report compatibility --rails-version=7.0 
=> Incompatible with Rails 7.0 (with new versions that are compatible):
These gems will need to be upgraded before upgrading to Rails 7.0.

dotenv-rails 2.7.5 - upgrade to 2.8.1
ombu_labs-hubspot 0.1.0 (loaded from git) - upgrade to 0.1.1
ombu_labs-notifications 0.1.0 (loaded from git) - upgrade to 0.1.2

3 gems incompatible with Rails 7.0
```

You can test this PR using `gem "next_rails", github: "fastruby/next_rails", branch: "ignore-rails-gems"`
