### PR TITLE
Pass trim_mode keyword arguments instead of positional argument to ERB.new

### DIFF
--- a/lib/next_rails/bundle_report.rb
+++ b/lib/next_rails/bundle_report.rb
@@ -49,7 +49,7 @@ module NextRails
 <%= incompatible_gems.length.to_s.red %> gems incompatible with Rails <%= rails_version %>
       ERB
 
-      puts ERB.new(template, nil, "-").result(binding)
+      puts ERB.new(template, trim_mode: "-").result(binding)
     end
 
     def gem_header(_gem)


### PR DESCRIPTION
## Description

This PR fixes #90

## Motivation and Context

The oldest available version of ERB (2.2.0) was already deprecating these positional parameters but that warning was behind a CLI flag. In newer versions this deprecation is displayed without the need of the CLI flag.

2.2.0 https://github.com/ruby/erb/blob/v2.2.0/lib/erb.rb#L815
2.2.1 https://github.com/ruby/erb/blob/v2.2.1/lib/erb.rb#L816

This change is backwards compatible because 2.2.0 is the oldest available version of ERB and it already prefers keyword arguments over positional arguments

## How Has This Been Tested?

I ran next_rails before and after this change in Ruby 3.1.3 (which uses ERB 2.2.3)

Before:
```
bundle_report --rails-version=7.1
/home/ariel/.asdf/installs/ruby/3.1.3/lib/ruby/3.1.0/erb.rb:814: warning: Passing safe_level with the 2nd argument of ERB.new is deprecated. Do not use it, and specify other arguments as keyword arguments.
/home/ariel/.asdf/installs/ruby/3.1.3/lib/ruby/3.1.0/erb.rb:817: warning: Passing trim_mode with the 3rd argument of ERB.new is deprecated. Use keyword argument like ERB.new(str, trim_mode: ...) instead.
=> Incompatible with Rails 7.1 (with no new compatible versions):
These gems will need to be removed or replaced before upgrading to Rails 7.1.

actionmailbox 7.0.4.2 - new version, 7.0.4.3, is not compatible with Rails 7.1
actiontext 7.0.4.2 - new version, 7.0.4.3, is not compatible with Rails 7.1

2 gems incompatible with Rails 7.1
```

After:
```
bundle_report --rails-version=7.1                                             
=> Incompatible with Rails 7.1 (with no new compatible versions):
These gems will need to be removed or replaced before upgrading to Rails 7.1.
                                                      
actionmailbox 7.0.4.2 - new version, 7.0.4.3, is not compatible with Rails 7.1
actiontext 7.0.4.2 - new version, 7.0.4.3, is not compatible with Rails 7.1
                                                      
2 gems incompatible with Rails 7.1
```

You can test this PR using gem "next_rails", github: "fastruby/next_rails", branch: "fix-erb-warning"

**I will abide by the [code of conduct](https://github.com/fastruby/next_rails/blob/main/CODE_OF_CONDUCT.md)**
