### PR TITLE
Update the `warn` method signature to support Rails 3.1

### DIFF
--- a/lib/deprecation_tracker.rb
+++ b/lib/deprecation_tracker.rb
@@ -18,13 +18,15 @@ class DeprecationTracker
       @callbacks ||= []
     end
 
-    def warn(*messages, uplevel: nil)
+    def warn(*messages, uplevel: nil, category: nil)
       KernelWarnTracker.callbacks.each do |callback|
         messages.each { |message| callback.(message) }
       end
 
       if Gem::Version.new(RUBY_VERSION) < Gem::Version.new("2.5.0")
-        super *messages
+        super(*messages)
+      elsif Gem::Version.new(RUBY_VERSION) < Gem::Version.new("3.0")
+        super(*messages, uplevel: nil)
       else
         super
       end


### PR DESCRIPTION
## Description

I encountered this error after adding `next_rails` to the project we're using in the Rails upgrade workshop. This error did not happen before adding `next_rails`
<img width="1065" alt="Screen_Shot_2023-04-06_at_9 37 30_PM" src="https://user-images.githubusercontent.com/748753/232130942-e2d4e517-fd1b-4cc0-8fae-55ad07f7efdd.png">

I traced it to a `warn` call in a gem being used by the project. The `warn` call in Rails 3 has a `category` keyword argument that our monkey patch in `next_rails` is not supporting https://github.com/countries/country_select/blob/7e73c4cc465aa61c268867b985837f2a126cffdc/lib/country_select/country_select_helper.rb#L10

## How Has This Been Tested?

Tested locally. Making this change resolves the error.

**I will abide by the [code of conduct](https://github.com/fastruby/next_rails/blob/main/CODE_OF_CONDUCT.md)**
