### PR TITLE
Support ERB syntax in old Ruby versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # main [(unreleased)](https://github.com/fastruby/next_rails/compare/v1.2.4...main)
 * Your changes/patches go here.
 
+- [BUGFIX: Support ERB versions older than 2.2.0](https://github.com/fastruby/next_rails/pull/100)
+
 # v1.2.4 / 2023-04-21 [(commits)](https://github.com/fastruby/next_rails/compare/v1.2.3...v1.2.4)
 
 - [BUGFIX: Update the warn method signature to support for Ruby 3]

--- a/lib/next_rails/bundle_report.rb
+++ b/lib/next_rails/bundle_report.rb
@@ -17,6 +17,10 @@ module NextRails
 
       incompatible_gems_by_state = incompatible_gems.group_by { |gem| gem.state(rails_version) }
 
+      puts erb_output(incompatible_gems_by_state, incompatible_gems, rails_version)
+    end
+
+    def erb_output(incompatible_gems_by_state, incompatible_gems, rails_version)
       template = <<-ERB
 <% if incompatible_gems_by_state[:found_compatible] -%>
 <%= "=> Incompatible with Rails #{rails_version} (with new versions that are compatible):".white.bold %>
@@ -49,7 +53,16 @@ module NextRails
 <%= incompatible_gems.length.to_s.red %> gems incompatible with Rails <%= rails_version %>
       ERB
 
-      puts ERB.new(template, trim_mode: "-").result(binding)
+      erb_version = ERB.version
+      if erb_version =~ /erb.rb \[([\d\.]+) .*\]/
+        erb_version = $1
+      end
+
+      if Gem::Version.new(erb_version) < Gem::Version.new("2.2")
+        ERB.new(template, nil, "-").result(binding)
+      else
+        ERB.new(template, trim_mode: "-").result(binding)
+      end
     end
 
     def gem_header(_gem)

--- a/next_rails.gemspec
+++ b/next_rails.gemspec
@@ -29,6 +29,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rspec", "~> 3.0"
   spec.add_development_dependency "simplecov", "~> 0.17.1"
   spec.add_development_dependency "timecop", "~> 0.9.1"
+  spec.add_development_dependency "byebug"
   spec.add_development_dependency "rexml", "3.1.7.3" # limited on purpose, new versions don't work with old rubies
   spec.add_development_dependency "webmock", "3.16.2" # limited on purpose, new versions don't work with old rubies
 end

--- a/spec/bundle_report_spec.rb
+++ b/spec/bundle_report_spec.rb
@@ -65,4 +65,13 @@ RSpec.describe NextRails::BundleReport do
       end
     end
   end
+
+  describe ".compatibility" do
+    describe "output" do
+      it "returns ERB generated output" do
+        output = NextRails::BundleReport.erb_output({}, [], 7.0)
+        expect(output).to match "gems incompatible with Rails 7.0"
+      end
+    end
+  end
 end


### PR DESCRIPTION
## Description
The bundler report compatibility command didn't work in old ERB version. This PR adds a test that exercises that line and also the fix calling `ERB.new` with different arguments depending on the ERB version.

## Motivation and Context

This issue https://github.com/fastruby/next_rails/issues/99

I think this is the same issue https://github.com/fastruby/next_rails/issues/96

## How Has This Been Tested?

Added automated tests, without this change it fails in Ruby 2.3

**I will abide by the [code of conduct](https://github.com/fastruby/next_rails/blob/main/CODE_OF_CONDUCT.md)**
