### PR TITLE
Fix Ruby 2.2 setup in github action

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,7 +13,23 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby-version: [3.2, 3.1, 3.0, 2.7, 2.6, 2.5, 2.4, 2.3, 2.2, 2.1, 2.0.0]
+        ruby-version: [3.2, 3.1, 3.0, 2.7, 2.6, 2.5, 2.4, 2.3]
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Ruby ${{ matrix.ruby-version }}
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ${{ matrix.ruby-version }}
+          bundler-cache: true
+      - name: Run rake task
+        run: bundle exec rake
+
+  test_older:
+    runs-on: ubuntu-20.04
+    strategy:
+      matrix:
+        ruby-version: [2.2, 2.1, 2.0.0]
 
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
When the tests start to run, the Ruby 2.2 tests have a bug that makes it fail and that produces a cancellation of all the other jobs in that matrix.

Seems to be a known issue and this PR adds the proposed workaround from this bug report https://github.com/ruby/setup-ruby/issues/496#issuecomment-1520667671 running 2.2 and older in a previous version of Ubuntu instead of Ubuntu latest

You can see in the other 2 latest PRs that it was failing for 2.2 always, and I ran all the versions manually for https://github.com/fastruby/next_rails/pull/100 and 2.2 keeps failing

![image](https://github.com/fastruby/next_rails/assets/188464/9ab00bd5-78f0-40ba-8d77-3fe987ce60a3)
![image](https://github.com/fastruby/next_rails/assets/188464/fc911f6b-1c93-46f1-90c5-b7c263c8db7d)
