### PR TITLE
Replace climate_control gem with stub_const

### DIFF
--- a/next_rails.gemspec
+++ b/next_rails.gemspec
@@ -1,4 +1,3 @@
-
 lib = File.expand_path("../lib", __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require "next_rails/version"
@@ -25,7 +24,6 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency "colorize", ">= 0.8.1"
   spec.add_development_dependency "bundler", ">= 1.16", "< 3.0"
-  spec.add_development_dependency "climate_control"
   spec.add_development_dependency "rake"
   spec.add_development_dependency "rspec", "~> 3.0"
   spec.add_development_dependency "simplecov", "~> 0.17.1"

--- a/spec/next_rails_spec.rb
+++ b/spec/next_rails_spec.rb
@@ -18,9 +18,8 @@ RSpec.describe NextRails do
           FileUtils.touch("Gemfile.next")
           NextRails.reset_next_bundle_gemfile
 
-          ClimateControl.modify BUNDLE_GEMFILE: "Gemfile.next" do
-            expect(NextRails.next?).to be_truthy
-          end
+          with_env("BUNDLE_GEMFILE" => "Gemfile.next")
+          expect(NextRails.next?).to be_truthy
         end
 
         context "when Gemfile.next file does not exist" do
@@ -28,9 +27,8 @@ RSpec.describe NextRails do
             FileUtils.rm("Gemfile.next")
             NextRails.reset_next_bundle_gemfile
 
-            ClimateControl.modify BUNDLE_GEMFILE: "Gemfile.next" do
-              expect(NextRails.next?).to be_falsey
-            end
+            with_env("BUNDLE_GEMFILE" => "Gemfile.next")
+            expect(NextRails.next?).to be_falsey
           end
         end
       end
@@ -40,9 +38,8 @@ RSpec.describe NextRails do
           FileUtils.touch("Gemfile4")
           NextRails.reset_next_bundle_gemfile
 
-          ClimateControl.modify BUNDLE_GEMFILE: "Gemfile4" do
-            expect(NextRails.next?).to be_falsey
-          end
+          with_env("BUNDLE_GEMFILE" => "Gemfile4")
+          expect(NextRails.next?).to be_falsey
 
           FileUtils.rm("Gemfile4")
         end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -46,5 +46,5 @@ RSpec.configure do |config|
 end
 
 def with_env(env_hash)
-  stub_const("ENV", env_hash)
+  stub_const("ENV", ENV.to_hash.merge!(env_hash))
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -19,7 +19,6 @@ end
 
 require "bundler/setup"
 require "next_rails"
-require "climate_control"
 
 require 'webmock/rspec'
 WebMock.disable_net_connect!(allow_localhost: true)
@@ -44,4 +43,8 @@ RSpec.configure do |config|
       with(headers: {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Host'=>'rubygems.org', 'User-Agent'=>'Ruby'}).
       to_return(status: 200, body: "[{\"number\": \"7.0.0\"}, {\"number\": \"6.1.6\"}]", headers: {})
   end
+end
+
+def with_env(env_hash)
+  stub_const("ENV", env_hash)
 end


### PR DESCRIPTION
Is there any reason you want to still using the gem?

## Description
Remove `climate_control` as a dependency we are implementing the `stub_const` method.

## Motivation and Context
Avoid having another dependency gem because old Ruby versions are complaining about it.

## How Has This Been Tested?
Wishing the RSpec tests

<!--- For example: I am using [Safari|Firefox|Chrome] then I visit [the users path] -->

## Screenshots:
<!-- Add screenshots (applicable to any UI changes) -->

**I will abide by the [code of conduct](https://github.com/fastruby/next_rails/blob/main/CODE_OF_CONDUCT.md)**
