### PR TITLE
Add shitlist path option to deprecations command.

### DIFF
--- a/exe/deprecations
+++ b/exe/deprecations
@@ -49,6 +49,7 @@ option_parser = OptionParser.new do |opts|
       bin/deprecations --next info # Show top ten deprecations for Rails 5
       bin/deprecations --pattern "ActiveRecord::Base" --verbose info # Show full details on deprecations matching pattern
       bin/deprecations --tracker-mode save --pattern "pass" run # Run tests that output deprecations matching pattern and update shitlist
+      bin/deprecations info --shitlist-path /spec/support/deprecations.log.json # Show top ten deprecations for a given file. 
 
     Modes:
       info
@@ -76,6 +77,10 @@ option_parser = OptionParser.new do |opts|
     options[:verbose] = true
   end
 
+  opts.on("--shitlist-path") do |shitlist_path|
+    options[:shitlist_path] = shitlist_path
+  end
+
   opts.on_tail("-h", "--help", "Prints this help") do
     puts opts
     exit
@@ -85,12 +90,15 @@ end
 option_parser.parse!
 
 options[:mode] = ARGV.last
-path = options[:next] ? "spec/support/deprecation_warning.next.shitlist.json" : "spec/support/deprecation_warning.shitlist.json"
+
+default_path = options[:next] ? "spec/support/deprecation_warning.next.shitlist.json" : "spec/support/deprecation_warning.shitlist.json"
+
+shitlist_path = options.fetch(:shitlist_path, path)
 
 pattern_string = options.fetch(:pattern, ".+")
 pattern = /#{pattern_string}/
 
-deprecation_warnings = JSON.parse(File.read(path)).each_with_object({}) do |(test_file, messages), hash|
+deprecation_warnings = JSON.parse(File.read(shitlist_path)).each_with_object({}) do |(test_file, messages), hash|
   filtered_messages = messages.select {|message| message.match(pattern) }
   hash[test_file] = filtered_messages if !filtered_messages.empty?
 end


### PR DESCRIPTION


## Description
<!--- Describe your changes in detail -->

This change aims to introduce a new option to the deprecations command to allow for a custom path to be defined.

It adds a new option "--shitlist-path" where the user could defined a custom deprecation json file path.

 ```
bin/deprecations --shitlist-path spec/support/deprecations.json info
```

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

The DeprecationTracker allows to define a "shitlist_path" option when when declaring a tracker for rspec or minitest.

But this custom path cannot be used with the "deprecations" command, since until now it expects a fixed path.


## How Has This Been Tested?
<!--- Include any relevant details about your testing environment and the steps you followed -->
<!--- For example: I am using [Safari|Firefox|Chrome] then I visit [the users path] -->

## Screenshots:
<!-- Add screenshots (applicable to any UI changes) -->

**I will abide by the [code of conduct](https://github.com/fastruby/next_rails/blob/main/CODE_OF_CONDUCT.md)**
