### PR TITLE
Add dual_run command

### DIFF
--- a/exe/dual_run
+++ b/exe/dual_run
@@ -1,0 +1,88 @@
+#!/usr/bin/env ruby
+
+require "pty"
+
+command = ARGV.join(" ")
+
+if command == ""
+  puts "No command specified"
+  exit 1
+end
+
+puts "Running in parallel:"
+puts "BUNDLE_GEMFILE=Gemfile.next #{command}"
+puts command
+puts ""
+
+current_output = ""
+current_status = nil
+should_exit = false
+
+# Run the "current" version in a thread. Capture it's output to print at the end
+# Using PTY to capture the colorized output
+current_command = Thread.new do
+  # stdout_err is the mixed output of stdout and std_err
+  PTY.spawn(command) do |stdout_err, stdin, pid|
+    char = stdout_err.getc
+    while !should_exit && char
+      current_output << char
+      char = stdout_err.getc
+    end
+  rescue Errno::EIO # always raised when PTY runs out of input
+  ensure
+    if should_exit
+      # kill process with a SIGINT signal
+      Process.kill 2, pid
+    else
+      Process.waitpid pid # Wait for PTY to complete before continuing
+      current_status = $?.exitstatus
+    end
+  end
+end
+
+next_status = nil
+
+# Run the "next" version in another thread
+next_command = Thread.new do
+  puts "next results"
+  puts "=" * 80
+  system("BUNDLE_GEMFILE=Gemfile.next #{command}")
+  next_status = $?.exitstatus
+end
+
+# Handle Ctrl+C
+Signal.trap("INT") do
+  # handle pressing Ctrl+C twice to kill the commands without waiting
+  if should_exit
+    Thread.kill(next_command)
+    Thread.kill(current_command)
+  end
+
+  should_exit = true
+end
+
+# Wait for the "next" command to finish first
+next_command.join
+
+puts ""
+puts ""
+puts ""
+
+# Then wait for the "current" command to print its output
+puts "(waiting for current command to finish)"
+current_command.join
+puts "current results"
+puts "=" * 80
+puts current_output
+
+# check exit statuses, if both are successful exit with 0
+if current_status == 0 && next_status == 0
+  exit 0
+elsif should_exit
+  puts "Terminated by user"
+  exit 1
+else
+  puts "Current command exited with: #{current_status}"
+  puts "Next command exited with: #{next_status}"
+  exit 1
+end


### PR DESCRIPTION
## Description

This PR fixes https://github.com/fastruby/next_rails/issues/111

We can now run the same command in the two versions in parallel, like: `dual_run bundle exec rspec spec/models`.

The output of that in a project would be this for example:

```
Running in parallel:
BUNDLE_GEMFILE=Gemfile.next bundle exec rspec spec/models/
bundle exec rspec spec/models/

next results
================================================================================

Randomized with seed 41263
...................

Finished in 0.25773 seconds (files took 4.02 seconds to load)
19 examples, 0 failures

Randomized with seed 41263




(waiting for current command to finish)
current results
================================================================================

Randomized with seed 40666
...................

Finished in 0.23505 seconds (files took 3.96 seconds to load)
19 examples, 0 failures

Randomized with seed 40666
```

## Motivation and Context

This command solves 2 problems:
- we can run the same test for example in parallel instead of sequentially, to save time
- we can run them in the same terminal

## How Has This Been Tested?

To test this, you can add this branch as a gem in the Gemfile:
```
gem "next_rails", github: "fastruby/next_rails", branch: "add-dual-run-command"
```

Then bundle both:
```
bundle update next_rails
BUNDLE_GEMFILE=Gemfile.next bundle update next_rails
```

Now, in the root of the project, the `dual_run` command should be available:
```
dual_run bundle exec rspec spec/models
```

I'm not really sure how would I test this with automated tests.

**I will abide by the [code of conduct](https://github.com/fastruby/next_rails/blob/main/CODE_OF_CONDUCT.md)**
