### PR TITLE
Fixes/last reference to colorize

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby-version: [3.2, 3.1, 3.0, 2.7, 2.6, 2.5, 2.4, 2.3]
+        ruby-version: ["3.3", "3.2", "3.1", "3.0", "2.7", "2.6"]
 
     steps:
       - uses: actions/checkout@v2

--- a/lib/next_rails/bundle_report/ruby_version_compatibility.rb
+++ b/lib/next_rails/bundle_report/ruby_version_compatibility.rb
@@ -1,6 +1,8 @@
-require "colorize"
+require "rainbow/refinement"
 
 class NextRails::BundleReport::RubyVersionCompatibility
+  using Rainbow
+
   MINIMAL_VERSION = 1.0
   attr_reader :gems, :options
 


### PR DESCRIPTION
## Description

Drop support of Ruby 2.5 and older. Also, fix the test suite.

## Motivation and Context

Test suite was broken. 

## How Has This Been Tested?

Test suite passes. 

**I will abide by the [code of conduct](https://github.com/fastruby/next_rails/blob/main/CODE_OF_CONDUCT.md)**
