### PR TITLE
Call Rainbow instead of Colorize

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 * Your changes/patches go here.
 
+- [CHORE: Update compatibility for Ruby versions to use Rainbow](https://github.com/fastruby/next_rails/pull/125)
 - [FEATURE: Support compatibility for Ruby versions](https://github.com/fastruby/next_rails/pull/116)
 - [CHORE: Remove GPL licensed dependency Colorize and replace it with Rainbow]
 

--- a/lib/next_rails/bundle_report/ruby_version_compatibility.rb
+++ b/lib/next_rails/bundle_report/ruby_version_compatibility.rb
@@ -1,4 +1,6 @@
-require "colorize"
+require "rainbow/refinement"
+
+using Rainbow
 
 class NextRails::BundleReport::RubyVersionCompatibility
   MINIMAL_VERSION = 1.0


### PR DESCRIPTION
## Description
Call Rainbow instead of Colorize in `bundle_report/ruby_version_compatibility.rb`

## Motivation and Context

Recentry the #120 PR removed Colorize in favor of Rainbow,
`bundle_report/ruby_version_compatibility.rb` was using Colorize and we need to update it to use Rainbow.

## How Has This Been Tested?
Some tests were failing because of this, now they are passing.

## Screenshots:
<!-- Add screenshots (applicable to any UI changes) -->

**I will abide by the [code of conduct](https://github.com/fastruby/next_rails/blob/main/CODE_OF_CONDUCT.md)**
