### PR TITLE
Remove older ruby tests

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -24,19 +24,3 @@ jobs:
           bundler-cache: true
       - name: Run rake task
         run: bundle exec rake
-
-  test_older:
-    runs-on: ubuntu-20.04
-    strategy:
-      matrix:
-        ruby-version: [2.2, 2.1, 2.0.0]
-
-    steps:
-      - uses: actions/checkout@v2
-      - name: Set up Ruby ${{ matrix.ruby-version }}
-        uses: ruby/setup-ruby@v1
-        with:
-          ruby-version: ${{ matrix.ruby-version }}
-          bundler-cache: true
-      - name: Run rake task
-        run: bundle exec rake

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 * Your changes/patches go here.
 
+- [CHORE: Remove 2.0.0, 2.1, 2.2 Ruby support](https://github.com/fastruby/next_rails/pull/126)
 - [CHORE: Update compatibility for Ruby versions to use Rainbow](https://github.com/fastruby/next_rails/pull/125)
 - [FEATURE: Support compatibility for Ruby versions](https://github.com/fastruby/next_rails/pull/116)
 - [CHORE: Remove GPL licensed dependency Colorize and replace it with Rainbow]


### PR DESCRIPTION
## Description
Ruby 2.0.0, 2.1, 2.2 does not support Rainbow 3, so, we are removing support for older Ruby versions.

## Motivation and Context
Moving away of the Colorize dependency gem because it uses GPL 2.0 license.
https://github.com/fastruby/next_rails/pull/120

## How Has This Been Tested?
Running the test suite

## Screenshots:
<!-- Add screenshots (applicable to any UI changes) -->

**I will abide by the [code of conduct](https://github.com/fastruby/next_rails/blob/main/CODE_OF_CONDUCT.md)**
