### PR TITLE
Use Rainbow directly instead of relying on String refinement.

### DIFF
--- a/exe/bundle_report
+++ b/exe/bundle_report
@@ -55,7 +55,7 @@ at_exit do
   begin
     option_parser.parse!
   rescue OptionParser::ParseError => e
-    STDERR.puts e.message.red
+    STDERR.puts Rainbow(e.message).red
     puts option_parser
     exit 1
   end

--- a/exe/deprecations
+++ b/exe/deprecations
@@ -1,10 +1,8 @@
 #!/usr/bin/env ruby
 require "json"
-require "rainbow/refinement"
+require "rainbow"
 require "optparse"
 require "set"
-
-using Rainbow
 
 def run_tests(deprecation_warnings, opts = {})
   tracker_mode = opts[:tracker_mode]
@@ -30,11 +28,11 @@ def print_info(deprecation_warnings, opts = {})
     end
   end.sort_by {|message, data| data[:occurrences] }.reverse.to_h
 
-  puts "Ten most common deprecation warnings:".underline
+  puts Rainbow("Ten most common deprecation warnings:").underline
   frequency_by_message.take(10).each do |message, data|
-    puts "Occurrences: #{data.fetch(:occurrences)}".bold
+    puts Rainbow("Occurrences: #{data.fetch(:occurrences)}").bold
     puts "Test files: #{data.fetch(:test_files).to_a.join(" ")}" if verbose
-    puts message.red
+    puts Rainbow(message).red
     puts "----------"
   end
 end
@@ -106,10 +104,10 @@ case options.fetch(:mode, "info")
 when "run" then run_tests(deprecation_warnings, next_mode: options[:next], tracker_mode: options[:tracker_mode])
 when "info" then print_info(deprecation_warnings, verbose: options[:verbose])
 when nil
-  STDERR.puts "Must pass a mode: run or info".red
+  STDERR.puts Rainbow("Must pass a mode: run or info").red
   puts option_parser
   exit 1
 else
-  STDERR.puts "Unknown mode: #{options[:mode]}".red
+  STDERR.puts Rainbow("Unknown mode: #{options[:mode]}").red
   exit 1
 end

--- a/lib/deprecation_tracker.rb
+++ b/lib/deprecation_tracker.rb
@@ -1,7 +1,5 @@
-require "rainbow/refinement"
+require "rainbow"
 require "json"
-
-using Rainbow
 
 # A shitlist for deprecation warnings during test runs. It has two modes: "save" and "compare"
 #
@@ -152,7 +150,7 @@ class DeprecationTracker
     end
 
     if changed_buckets.length > 0
-      message = <<-MESSAGE.red
+      message = <<-MESSAGE
         ⚠️  Deprecation warnings have changed!
 
         Code called by the following spec files is now generating different deprecation warnings:
@@ -170,7 +168,7 @@ class DeprecationTracker
         See \e[4;37mdev-docs/testing/deprecation_tracker.md\e[0;31m for more information.
       MESSAGE
 
-      raise UnexpectedDeprecations, message
+      raise UnexpectedDeprecations, Rainbow(message).red
     end
   end
 

--- a/lib/next_rails/bundle_report.rb
+++ b/lib/next_rails/bundle_report.rb
@@ -1,10 +1,8 @@
-require "rainbow/refinement"
+require "rainbow"
 require "cgi"
 require "erb"
 require "json"
 require "net/http"
-
-using Rainbow
 
 module NextRails
   module BundleReport
@@ -27,8 +25,8 @@ module NextRails
     def erb_output(incompatible_gems_by_state, incompatible_gems, rails_version)
       template = <<-ERB
 <% if incompatible_gems_by_state[:found_compatible] -%>
-<%= "=> Incompatible with Rails #{rails_version} (with new versions that are compatible):".white.bold %>
-<%= "These gems will need to be upgraded before upgrading to Rails #{rails_version}.".italic %>
+<%= Rainbow("=> Incompatible with Rails #{rails_version} (with new versions that are compatible):").white.bold %>
+<%= Rainbow("These gems will need to be upgraded before upgrading to Rails #{rails_version}.").italic %>
 
 <% incompatible_gems_by_state[:found_compatible].each do |gem| -%>
 <%= gem_header(gem) %> - upgrade to <%= gem.latest_compatible_version.version %>
@@ -36,8 +34,8 @@ module NextRails
 
 <% end -%>
 <% if incompatible_gems_by_state[:incompatible] -%>
-<%= "=> Incompatible with Rails #{rails_version} (with no new compatible versions):".white.bold %>
-<%= "These gems will need to be removed or replaced before upgrading to Rails #{rails_version}.".italic %>
+<%= Rainbow("=> Incompatible with Rails #{rails_version} (with no new compatible versions):").white.bold %>
+<%= Rainbow("These gems will need to be removed or replaced before upgrading to Rails #{rails_version}.").italic %>
 
 <% incompatible_gems_by_state[:incompatible].each do |gem| -%>
 <%= gem_header(gem) %> - new version, <%= gem.latest_version.version %>, is not compatible with Rails #{rails_version}
@@ -45,16 +43,16 @@ module NextRails
 
 <% end -%>
 <% if incompatible_gems_by_state[:no_new_version] -%>
-<%= "=> Incompatible with Rails #{rails_version} (with no new versions):".white.bold %>
-<%= "These gems will need to be upgraded by us or removed before upgrading to Rails #{rails_version}.".italic %>
-<%= "This list is likely to contain internal gems, like Cuddlefish.".italic %>
+<%= Rainbow("=> Incompatible with Rails #{rails_version} (with no new versions):").white.bold %>
+<%= Rainbow("These gems will need to be upgraded by us or removed before upgrading to Rails #{rails_version}.").italic %>
+<%= Rainbow("This list is likely to contain internal gems, like Cuddlefish.").italic %>
 
 <% incompatible_gems_by_state[:no_new_version].each do |gem| -%>
 <%= gem_header(gem) %> - new version not found
 <% end -%>
 
 <% end -%>
-<%= incompatible_gems.length.to_s.red %> gems incompatible with Rails <%= rails_version %>
+<%= Rainbow(incompatible_gems.length.to_s).red %> gems incompatible with Rails <%= rails_version %>
       ERB
 
       erb_version = ERB.version
@@ -70,8 +68,8 @@ module NextRails
     end
 
     def gem_header(_gem)
-      header = "#{_gem.name} #{_gem.version}".bold
-      header << " (loaded from git)".magenta if _gem.sourced_from_git?
+      header = Rainbow("#{_gem.name} #{_gem.version}").bold
+      header << Rainbow(" (loaded from git)").magenta if _gem.sourced_from_git?
       header
     end
 
@@ -158,14 +156,14 @@ module NextRails
         header = "#{gem.name} #{gem.version}"
 
         puts <<-MESSAGE
-          #{header.bold.white}: released #{gem.age} (latest version, #{gem.latest_version.version}, released #{gem.latest_version.age})
+          #{Rainbow(header.bold.white)}: released #{gem.age} (latest version, #{gem.latest_version.version}, released #{gem.latest_version.age})
         MESSAGE
       end
 
       percentage_out_of_date = ((out_of_date_gems.count / total_gem_count.to_f) * 100).round
       footer = <<-MESSAGE
-        #{sourced_from_git_count.to_s.yellow} gems are sourced from git
-        #{out_of_date_gems.count.to_s.red} of the #{total_gem_count} gems are out-of-date (#{percentage_out_of_date}%)
+        #{Rainbow(sourced_from_git_count.to_s).yellow} gems are sourced from git
+        #{Rainbow(out_of_date_gems.count.to_s).red} of the #{total_gem_count} gems are out-of-date (#{percentage_out_of_date}%)
       MESSAGE
 
       puts ''

--- a/lib/next_rails/bundle_report/ruby_version_compatibility.rb
+++ b/lib/next_rails/bundle_report/ruby_version_compatibility.rb
@@ -1,8 +1,6 @@
-require "rainbow/refinement"
+require "rainbow"
 
 class NextRails::BundleReport::RubyVersionCompatibility
-  using Rainbow
-
   MINIMAL_VERSION = 1.0
   attr_reader :gems, :options
 
@@ -20,11 +18,11 @@ class NextRails::BundleReport::RubyVersionCompatibility
   private
 
   def message
-    output = "=> Incompatible gems with Ruby #{ruby_version}:".white.bold
+    output = Rainbow("=> Incompatible gems with Ruby #{ruby_version}:").white.bold
     incompatible.each do |gem|
-      output += "\n#{gem.name} - required Ruby version: #{gem.gem_specification.required_ruby_version}".magenta
+      output += Rainbow("\n#{gem.name} - required Ruby version: #{gem.gem_specification.required_ruby_version}").magenta
     end
-    output += "\n\n#{incompatible.length} incompatible #{incompatible.one? ? 'gem' : 'gems' } with Ruby #{ruby_version}".red
+    output += Rainbow("\n\n#{incompatible.length} incompatible #{incompatible.one? ? 'gem' : 'gems' } with Ruby #{ruby_version}").red
     output
   end
 
@@ -37,7 +35,7 @@ class NextRails::BundleReport::RubyVersionCompatibility
   end
 
   def invalid_message
-    "=> Invalid Ruby version: #{options[:ruby_version]}.".red.bold
+    Rainbow("=> Invalid Ruby version: #{options[:ruby_version]}.").red.bold
   end
 
   def valid?

--- a/spec/next_rails/bundle_report_spec.rb
+++ b/spec/next_rails/bundle_report_spec.rb
@@ -1,9 +1,6 @@
 # frozen_string_literal: true
 
-require "rainbow/refinement"
-
-using Rainbow
-
+require "rainbow"
 require "spec_helper"
 
 RSpec.describe NextRails::BundleReport do
@@ -33,14 +30,14 @@ RSpec.describe NextRails::BundleReport do
       it 'invokes $stdout.puts properly', :aggregate_failures do
         allow($stdout)
           .to receive(:puts)
-          .with("#{'alpha 0.0.1'.bold.white}: released #{alpha_age} (latest version, 0.0.2, released #{bravo_age})\n")
+          .with("#{Rainbow('alpha 0.0.1').bold.white}: released #{alpha_age} (latest version, 0.0.2, released #{bravo_age})\n")
         allow($stdout)
           .to receive(:puts)
-          .with("#{'bravo 0.2.0'.bold.white}: released #{bravo_age} (latest version, 0.2.2, released #{charlie_age})\n")
+          .with("#{Rainbow('bravo 0.2.0').bold.white}: released #{bravo_age} (latest version, 0.2.2, released #{charlie_age})\n")
         allow($stdout).to receive(:puts).with('')
         allow($stdout).to receive(:puts).with(<<-EO_MULTLINE_STRING)
-          #{'1'.yellow} gems are sourced from git
-          #{'2'.red} of the 2 gems are out-of-date (100%)
+          #{Rainbow('1').yellow} gems are sourced from git
+          #{Rainbow('2').red} of the 2 gems are out-of-date (100%)
         EO_MULTLINE_STRING
       end
     end


### PR DESCRIPTION
## Description
Use the Rainbow gem directly (i.e. `Rainbow("text").red`) instead of relying on the String monkey patching.

I checked for usage of the following methods:

- background
- bg
- black
- blink
- blue
- bold
- bright
- color
- cross_out
- cyan
- dark
- faint
- fg
- foreground
- green
- hide
- inverse
- italic
- magenta
- red
- reset
- strike
- underline
- white
- yellow

Those are the basic methods defined by the rainbow. I skipped the methods covered by the problematic "method_missing".

## Motivation and Context
Fix https://github.com/fastruby/next_rails/issues/130

As raised in the https://github.com/fastruby/next_rails/issues/130, the release 1.4.0 impacted performance of a couple apps. The underlying issue is that the rainbow gem is refining the String class and that the `method_missing` is overwritten.

The `refine` seems have some performance issues on some of the ruby releases: https://bugs.ruby-lang.org/issues/18572

This PR is a proposal for mitigating this issue without a need of fixing rainbow gem nor upgrading the ruby version. If the changes here aren't too annoying maybe that could be a way to go? :)

## How Has This Been Tested?
I run it against one of the endpoint of the affected application. 

average response of 100 requests:
- v1.3.0: 816.07ms
- v1.4.0: 951.84ms
- patch: 816.83ms

I am not sure whether there is a way of testing this in any other way 🤷 
