### PR TITLE
fix(rainbow change): the methods (bold & white) are not on String but…

### DIFF
--- a/lib/next_rails/bundle_report.rb
+++ b/lib/next_rails/bundle_report.rb
@@ -156,7 +156,7 @@ module NextRails
         header = "#{gem.name} #{gem.version}"
 
         puts <<-MESSAGE
-          #{Rainbow(header.bold.white)}: released #{gem.age} (latest version, #{gem.latest_version.version}, released #{gem.latest_version.age})
+          #{Rainbow(header).bold.white}: released #{gem.age} (latest version, #{gem.latest_version.version}, released #{gem.latest_version.age})
         MESSAGE
       end
 


### PR DESCRIPTION
… Rainbow

## Description

Bug from the change from colorize gem to Rainbow.

## Motivation and Context

I got this method running bundle_report outdated

```undefined method `bold' for an instance of String (NoMethodError)

          #{Rainbow(header.bold.white)}: released #{gem.age} (latest version, #{gem.latest_version.version}, released #{gem.latest_version.age})```

## How Has This Been Tested?

Ran the test suite. Used the gem in my own gemfil.

## Screenshots:

It's a small change.

**I will abide by the [code of conduct](https://github.com/fastruby/next_rails/blob/main/CODE_OF_CONDUCT.md)**
