### PR TITLE
Add Ruby 3.4 support

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby-version: ["3.3", "3.2", "3.1", "3.0", "2.7", "2.6"]
+        ruby-version: ["3.4", "3.3", "3.2", "3.1", "3.0", "2.7", "2.6"]
 
     steps:
       - uses: actions/checkout@v2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # main [(unreleased)](https://github.com/fastruby/next_rails/compare/v1.4.2...main)
 
+- [Add Ruby 3.4 support](https://github.com/fastruby/next_rails/pull/133)
+
 * Your changes/patches go here.
 
 # v1.4.2 / 2024-10-25 [(commits)](https://github.com/fastruby/next_rails/compare/v1.4.1...v1.4.2)

--- a/next_rails.gemspec
+++ b/next_rails.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |spec|
   spec.homepage     = "https://github.com/fastruby/next_rails"
   spec.license       = "MIT"
 
-  spec.required_ruby_version = ">= 2.0", "< 3.5"
+  spec.required_ruby_version = ">= 2.0"
 
   spec.files         = `git ls-files -z`.split("\x0").reject do |f|
     f.match(%r{^(test|spec|features)/})

--- a/next_rails.gemspec
+++ b/next_rails.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |spec|
   spec.homepage     = "https://github.com/fastruby/next_rails"
   spec.license       = "MIT"
 
-  spec.required_ruby_version = ">= 2.0"
+  spec.required_ruby_version = ">= 2.0", "< 3.5"
 
   spec.files         = `git ls-files -z`.split("\x0").reject do |f|
     f.match(%r{^(test|spec|features)/})
@@ -30,5 +30,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "timecop", "~> 0.9.1"
   spec.add_development_dependency "byebug"
   spec.add_development_dependency "rexml", "3.3.8" # limited on purpose, new versions don't work with old rubies
-  spec.add_development_dependency "webmock", "3.16.2" # limited on purpose, new versions don't work with old rubies
+  spec.add_development_dependency "webmock", "3.20.0"
 end


### PR DESCRIPTION
## Description
Ruby 3.4 is removing the `base64` default gem to [became bundled](https://rubyreferences.github.io/rubychanges/3.4.html#default-gems-that-became-bundled)

```
/Users/juan/.asdf/installs/ruby/3.3.5/lib/ruby/gems/3.3.0/gems/webmock-3.16.2/lib/webmock.rb:14: warning: base64 was loaded from the standard library, but will no longer be part of the default gems starting from Ruby 3.4.0.
You can add base64 to your Gemfile or gemspec to silence this warning.
```

Making the current webmock (v3.16.2) gem incompatible because it has a dependency on the `base64` gem,
to fix it we are bumping webmock to v3.20.0 which [removed the
`base64`](https://github.com/bblimke/webmock/pull/1046) dependency.

> [!NOTE]
> As an alternative solution, we can leave the current `webmock` version untoched
and add the `base64` gem as a dependency.


## Motivation and Context
Increase the compatibility of the project with the latest Ruby versions.

## How Has This Been Tested?
- Run the test suite

## Screenshots:
<!-- Add screenshots (applicable to any UI changes) -->

**I will abide by the [code of conduct](https://github.com/fastruby/next_rails/blob/main/CODE_OF_CONDUCT.md)**
