### PR TITLE
Add next_rails --init to replace next --init

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # main [(unreleased)](https://github.com/fastruby/next_rails/compare/v1.4.2...main)
 
+- [Add next_rails --init](https://github.com/fastruby/next_rails/pull/139)
 - [Add Ruby 3.4 support](https://github.com/fastruby/next_rails/pull/133)
 
 * Your changes/patches go here.

--- a/exe/next.sh
+++ b/exe/next.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 if [[ "${@}" == "--init" ]]; then
+  echo "The next --init command is deprecated. Please use the next_rails --init command instead."
   # Add next? top of Gemfile
   cat <<-STRING > Gemfile.tmp
 def next?

--- a/exe/next_rails
+++ b/exe/next_rails
@@ -1,6 +1,7 @@
 #!/usr/bin/env ruby
 require "optparse"
 require "next_rails/version"
+require "next_rails"
 
 options = {}
 option_parser = OptionParser.new do |opts|
@@ -10,6 +11,10 @@ option_parser = OptionParser.new do |opts|
     Examples:
       bin/next_rails --version info # Show the version of the gem installed
   MESSAGE
+
+  opts.on("--init", "Setup the dual-boot configuration") do
+    options[:init] = true
+  end
 
   opts.on("--version", "show version of the gem") do
     options[:version] = true
@@ -22,6 +27,8 @@ option_parser = OptionParser.new do |opts|
 end
 
 option_parser.parse!
+
+puts NextRails::Init.call if options.fetch(:init, false)
 
 if options.fetch(:version, false)
   puts NextRails::VERSION

--- a/lib/next_rails.rb
+++ b/lib/next_rails.rb
@@ -2,6 +2,7 @@
 
 require "next_rails/gem_info"
 require "next_rails/version"
+require "next_rails/init"
 require "next_rails/bundle_report"
 require "next_rails/bundle_report/ruby_version_compatibility"
 require "deprecation_tracker"

--- a/lib/next_rails/init.rb
+++ b/lib/next_rails/init.rb
@@ -1,0 +1,82 @@
+# frozen_string_literal: true
+
+require 'fileutils'
+
+module NextRails
+  # This class is responsible for installing the dual-boot files for your.
+  class Init
+    def self.call
+      new.call
+    end
+
+    def call
+      return gemfiles_message unless gemfiles?
+      return next_gemfiles_message if next_gemfiles?
+
+      add_next_conditional
+      create_sym_link
+      copy_gemfile_lock
+      message
+    end
+
+    private
+
+    def gemfiles?
+      %w[Gemfile Gemfile.lock].any? { |file| File.exist?(file) }
+    end
+
+    def gemfiles_message
+      'You must have a Gemfile and Gemfile.lock to run the next_rails --init command.'
+    end
+
+    def next_gemfiles?
+      %w[Gemfile.next Gemfile.next.lock].any? { |file| File.exist?(file) }
+    end
+
+    def next_gemfiles_message
+      'The next_rails --init command has already been run.'
+    end
+
+    def add_next_conditional
+      File.open('Gemfile.tmp', 'w') do |file|
+        file.write <<-STRING
+def next?
+  File.basename(__FILE__) == "Gemfile.next"
+end
+        STRING
+      end
+
+      File.open('Gemfile', 'r') do |original|
+        File.open('Gemfile.tmp', 'a') do |temp|
+          temp.write(original.read)
+        end
+      end
+
+      File.rename('Gemfile.tmp', 'Gemfile')
+    end
+
+    def create_sym_link
+      File.symlink('Gemfile', 'Gemfile.next')
+    end
+
+    def copy_gemfile_lock
+      FileUtils.cp('Gemfile.lock', 'Gemfile.next.lock')
+    end
+
+    def message
+      <<-MESSAGE
+Created Gemfile.next (a symlink to your Gemfile). Your Gemfile has been modified to support dual-booting!
+
+There's just one more step: modify your Gemfile to use a newer version of Rails using the \`next?\` helper method.
+
+For example, here's how to go from 5.2.8.1 to 6.0.6.1:
+
+if next?
+  gem "rails", "6.0.6.1"
+else
+  gem "rails", "5.2.8.1"
+end
+      MESSAGE
+    end
+  end
+end

--- a/spec/next_rails/init_spec.rb
+++ b/spec/next_rails/init_spec.rb
@@ -1,0 +1,64 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'fileutils'
+
+RSpec.describe NextRails::Init do
+  let(:gemfile_content) { "source 'https://rubygems.org'\ngem 'rails'\n" }
+
+  before(:all) do
+    FileUtils.cp('Gemfile', 'Gemfile.original')
+  end
+
+  after(:all) do
+    FileUtils.cp('Gemfile.original', 'Gemfile')
+    FileUtils.rm_f('Gemfile.original')
+  end
+
+  before do
+    FileUtils.rm_f('Gemfile')
+    FileUtils.rm_f('Gemfile.lock')
+    FileUtils.rm_f('Gemfile.next')
+    FileUtils.rm_f('Gemfile.next.lock')
+  end
+
+  after do
+    FileUtils.rm_f('Gemfile')
+    FileUtils.rm_f('Gemfile.lock')
+    FileUtils.rm_f('Gemfile.next')
+    FileUtils.rm_f('Gemfile.next.lock')
+  end
+
+  describe '.call' do
+    it 'already has next Gemfile files' do
+      File.write('Gemfile', gemfile_content)
+      FileUtils.touch('Gemfile.lock')
+      File.write('Gemfile.next', gemfile_content)
+
+      expect(described_class.call).to eq('The next_rails --init command has already been run.')
+    end
+
+    it 'does not have Gemfile files' do
+      expect(described_class.call).to eq('You must have a Gemfile and Gemfile.lock to run the next_rails --init command.')
+    end
+
+    it 'creates Gemfile.next and Gemfile.next.lock' do
+      File.write('Gemfile', gemfile_content)
+      FileUtils.touch('Gemfile.lock')
+
+      expect do
+        described_class.call
+      end.to change { File.exist?('Gemfile.next') }.from(false).to(true)
+         .and change { File.exist?('Gemfile.next.lock') }.from(false).to(true)
+    end
+
+    it 'returns a success message' do
+      File.write('Gemfile', gemfile_content)
+      FileUtils.touch('Gemfile.lock')
+
+      message = described_class.call
+      expect(message).to include('Created Gemfile.next (a symlink to your Gemfile).')
+      expect(message).to include("For example, here's how to go from 5.2.8.1 to 6.0.6.1:")
+    end
+  end
+end


### PR DESCRIPTION
## Description
1. I added a message to deprecate the current `next --init` command
   (eventually, we should remove it).
2. Moved the `next --init` functionality into the `NextRails::Init` class
3. Still need to move the `bundle exec next` functionallity. (next step? depends on the acceptance of this PR).

## Motivation and Context
If the user has the `next` command installed from `npm install -g next`, the `next --init` command will not work.
This is a problem because the user will not know how to call the `next` command.

It is reported here:
Closes https://github.com/fastruby/next_rails/issues/113

## How Has This Been Tested?
- I have tested this by running the `next --init` command and checking that the message is displayed.
- I have added automated tests to check the functionality of the `NextRails::Init` class.

## Screenshots:

Added a deprecation warning when running `next --init`
![Screenshot 2025-02-17 at 17 10 57](https://github.com/user-attachments/assets/6dd55359-6451-42e9-9178-45294ca17447)


When the command creates the `Gemfile.next` and `Gemfile.next.lock` it shows the same message as `next --init` has been showing:

![Screenshot 2025-02-17 at 17 12 50](https://github.com/user-attachments/assets/3ccd7c54-d575-4ea0-a95e-66bbcbd69877)

If the `next_rails --init` gem was run previously and the `Gemfile.next` and `Gemfile.next.lock` already exist it does not run the command and shows a message instead.
![Screenshot 2025-02-17 at 17 14 03](https://github.com/user-attachments/assets/1fe41cbb-3ae0-4d31-acae-7714a219b70c)


Now the `--init` command is part of the `--help` output


![Screenshot 2025-02-17 at 17 26 36](https://github.com/user-attachments/assets/64953ac1-7251-443f-850f-0ad470f09de0)


**I will abide by the [code of conduct](https://github.com/fastruby/next_rails/blob/main/CODE_OF_CONDUCT.md)**
