### PR TITLE
Release work for v1.4.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,13 @@
-# main [(unreleased)](https://github.com/fastruby/next_rails/compare/v1.4.2...main)
+# main [(unreleased)](https://github.com/fastruby/next_rails/compare/v1.4.3...main)
+
+- [BUGFIX: example](https://github.com/fastruby/next_rails/pull/<number>)
+
+* Your changes/patches go here.
+
+# v1.4.3 / 2025-02-20 [(commits)](https://github.com/fastruby/next_rails/compare/v1.4.2...v1.4.3)
 
 - [Add next_rails --init](https://github.com/fastruby/next_rails/pull/139)
 - [Add Ruby 3.4 support](https://github.com/fastruby/next_rails/pull/133)
-
-* Your changes/patches go here.
 
 # v1.4.2 / 2024-10-25 [(commits)](https://github.com/fastruby/next_rails/compare/v1.4.1...v1.4.2)
 

--- a/lib/next_rails/version.rb
+++ b/lib/next_rails/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module NextRails
-  VERSION = "1.4.2"
+  VERSION = "1.4.3"
 end


### PR DESCRIPTION
## Description
- [x] Add new next_rails --init command
- [x] Add Ruby 3.4 support

## Motivation and Context
Increase Ruby support, and deprecate the `next --init` command because it might cause some issues when the user has the `next` JS command installed.

## How Has This Been Tested?
- [x] Automated tests

## Screenshots:
<!-- Add screenshots (applicable to any UI changes) -->

**I will abide by the [code of conduct](https://github.com/fastruby/next_rails/blob/main/CODE_OF_CONDUCT.md)**
