### PR TITLE
Test Ruby 2.5 in CI 

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby-version: ["3.4", "3.3", "3.2", "3.1", "3.0", "2.7", "2.6"]
+        ruby-version: ["3.4", "3.3", "3.2", "3.1", "3.0", "2.7", "2.6", "2.5"]
 
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
## Description

This is related to https://github.com/fastruby/next_rails/issues/135

## Motivation and Context

Testing locally with Ruby 2.5 *just works* so I wanted to see if CI worked.

## How Has This Been Tested?

`bundle exec rake test`

## Screenshots:

N/A

**I will abide by the [code of conduct](https://github.com/fastruby/next_rails/blob/main/CODE_OF_CONDUCT.md)**
