### PR TITLE
Update deprecation tracker to support newer Rails versions (7.1+)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 * Your changes/patches go here.
 
+- [FEATURE: Update deprecation tracker to support newer Rails versions (7.1+)](https://github.com/fastruby/next_rails/pull/142)
+
 # v1.4.3 / 2025-02-20 [(commits)](https://github.com/fastruby/next_rails/compare/v1.4.2...v1.4.3)
 
 - [Add next_rails --init](https://github.com/fastruby/next_rails/pull/139)


### PR DESCRIPTION
## Description
Since Rails 7.1 the preferred way to track deprecations is to access the deprecation trackers via `Rails.application.deprecators`.

Here, we change the implementation to use that if it is available, otherwise fallback to tracking deprecations via the `ActiveSupport::Deprecation` singleton object for older Rails versions.

Related Rails changes: 
- [Add Rails.application.deprecators](https://github.com/rails/rails/pull/46049#top)
- [Deprecate ActiveSupport::Deprecation singleton usage](https://github.com/rails/rails/pull/47354)

## Motivation and Context
This is required to avoid getting deprecation warnings when using `next_rails` on Rails 7.1+ versions. 

```
DEPRECATION WARNING: Calling behavior on ActiveSupport::Deprecation is deprecated and will be removed from Rails (use Rails.
application.deprecators[framework].behavior where framework is for example :active_record instead) (called from block in <to
p (required)> at /Users/sorendaugaard/xxxx/spec/rails_helper.rb:300)
```

Additionally, eventually access via the singleton will be retired, this change will ensure we can still track deprecations when that happens. 

## How Has This Been Tested?
I added new specs to test this functionality. 

Additionally, I tested this against a Rails 7.1 project and check that we received the expected deprecation warnings. 

## Screenshots:
n/a


**I will abide by the [code of conduct](https://github.com/fastruby/next_rails/blob/main/CODE_OF_CONDUCT.md)** ✅ 
