### PR TITLE
Release work for v1.4.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,12 @@
-# main [(unreleased)](https://github.com/fastruby/next_rails/compare/v1.4.4...main)
+# main [(unreleased)](https://github.com/fastruby/next_rails/compare/v1.4.5...main)
 
 - [BUGFIX: example](https://github.com/fastruby/next_rails/pull/<number>)
-- [Move rails_version compatibility to its own class](https://github.com/fastruby/next_rails/pull/137)
 
 * Your changes/patches go here.
+
+# v1.4.5 / 2025-03-07 [(commits)](https://github.com/fastruby/next_rails/compare/v1.4.4...v1.4.5)
+
+- [Move rails_version compatibility to its own class](https://github.com/fastruby/next_rails/pull/137)
 
 # v1.4.4 / 2025-02-26 [(commits)](https://github.com/fastruby/next_rails/compare/v1.4.3...v1.4.4)
 

--- a/lib/next_rails/version.rb
+++ b/lib/next_rails/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module NextRails
-  VERSION = "1.4.4"
+  VERSION = "1.4.5"
 end


### PR DESCRIPTION
## Description

Release work around the rails compatibility extraction.

## Motivation and Context

I need to use the `incompatible_gems_by_state` from the rails incompatibility report outside of the gem, and the #137 is exposing it.

## How Has This Been Tested?

Running the test suite and added a few more tests.

## Screenshots:
<!-- Add screenshots (applicable to any UI changes) -->

**I will abide by the [code of conduct](https://github.com/fastruby/next_rails/blob/main/CODE_OF_CONDUCT.md)**
