### PR TITLE
Exclude .gem binary to be commited

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@
 
 .ruby-version
 Gemfile.lock
+.gem


### PR DESCRIPTION
## Description
I just release a new gem and noticed that git was tracking the `.gem` binary file.
since we won't commit it by accident, I added it to the `.gitignore` file.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Include any relevant details about your testing environment and the steps you followed -->
<!--- For example: I am using [Safari|Firefox|Chrome] then I visit [the users path] -->

## Screenshots:
<!-- Add screenshots (applicable to any UI changes) -->

**I will abide by the [code of conduct](https://github.com/fastruby/next_rails/blob/main/CODE_OF_CONDUCT.md)**
