### PR TITLE
Fix typo `next_next` -> `next_rails`

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,7 +140,7 @@ next_rails --help # For more options and examples
 This command helps you dual-boot your application.
 
 ```bash
-next_next --init    # Create Gemfile.next and Gemfile.next.lock
+next_rails --init    # Create Gemfile.next and Gemfile.next.lock
 vim Gemfile         # Tweak your dependencies conditionally using `next?`
 next bundle install # Install new gems
 next rails s        # Start server using Gemfile.next


### PR DESCRIPTION
## Description
Replace `next_next` with `next_rails` in the README.md.

## Motivation and Context
See: #143.

## How Has This Been Tested?
It's just documentation change.

## Screenshots:
Not neccessary.

**I will abide by the [code of conduct](https://github.com/fastruby/next_rails/blob/main/CODE_OF_CONDUCT.md)**
