### PR TITLE
BUG-149: Fix compatibilities performance bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 * Your changes/patches go here.
 
+- [BUFIX: Fix compatibilities performance bug](https://github.com/fastruby/next_rails/pull/150)
+
 # v1.4.5 / 2025-03-07 [(commits)](https://github.com/fastruby/next_rails/compare/v1.4.4...v1.4.5)
 
 - [Move rails_version compatibility to its own class](https://github.com/fastruby/next_rails/pull/137)

--- a/lib/next_rails/gem_info.rb
+++ b/lib/next_rails/gem_info.rb
@@ -109,7 +109,7 @@ module NextRails
 
     def find_latest_compatible(rails_version: nil)
       dependency = Gem::Dependency.new(@name)
-      fetcher = Gem::SpecFetcher.new
+      fetcher = Gem::SpecFetcher.fetcher # Use fetcher instead of ::new to reduce object allocation.
 
       # list all available data for released gems
       list, errors = fetcher.available_specs(:released)

--- a/spec/next_rails/gem_info_spec.rb
+++ b/spec/next_rails/gem_info_spec.rb
@@ -83,7 +83,7 @@ RSpec.describe NextRails::GemInfo do
       # Set up a mock SpecFetcher to return an empty list
       fetcher_double = double("spec_fetcher")
       allow(fetcher_double).to receive(:available_specs).and_return([[],[]])
-      allow(Gem::SpecFetcher).to receive(:new).and_return(fetcher_double)
+      allow(Gem::SpecFetcher).to receive(:fetcher).and_return(fetcher_double)
 
       gem_info = NextRails::GemInfo.new(gem)
       gem_info.find_latest_compatible


### PR DESCRIPTION
Use fetcher instead of new when we use Gem::SpecFetcher

Fixes: https://github.com/fastruby/next_rails/issues/149

## Description
<!--- Describe your changes in detail -->

Use [fetcher](https://rubyapi.org/3.4/o/gem/specfetcher#method-c-fetcher) instead of new when we use Gem::SpecFetcher
Fixes: https://github.com/fastruby/next_rails/issues/149


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Include any relevant details about your testing environment and the steps you followed -->
<!--- For example: I am using [Safari|Firefox|Chrome] then I visit [the users path] -->

Using `time` before and after:
- Before: `42.34s user 1.83s system 97% cpu 45.095 total`
- After: `5.68s user 0.61s system 72% cpu 8.728 total`

Using automated tests.

## Screenshots:
<!-- Add screenshots (applicable to any UI changes) -->

Using stack prof:
| Before | After |
| - | - |
| ![image](https://github.com/user-attachments/assets/c1ea2e8f-1289-4588-b1cd-6b830164d6b5)  |  ![image](https://github.com/user-attachments/assets/eba61493-fc91-49eb-90b9-99fbb801c81e)  |

**I will abide by the [code of conduct](https://github.com/fastruby/next_rails/blob/main/CODE_OF_CONDUCT.md)**
