### PR TITLE
Bring back support of Ruby 2.3, 2.4 and 2.5

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby-version: ["3.4", "3.3", "3.2", "3.1", "3.0", "2.7", "2.6", "2.5"]
+        ruby-version: ["3.4", "3.3", "3.2", "3.1", "3.0", "2.7", "2.6", "2.5", "2.4", "2.3"]
 
     steps:
       - uses: actions/checkout@v2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - [BUGFIX: example](https://github.com/fastruby/next_rails/pull/<number>)
 - [CHORE: Create an entry point for the BundleReport command](https://github.com/fastruby/next_rails/pull/154)
+- [CHORE: Bring back support of Ruby 2.3, 2.4 and 2.5](https://github.com/fastruby/next_rails/pull/155)
 
 * Your changes/patches go here.
 

--- a/lib/next_rails/bundle_report/cli.rb
+++ b/lib/next_rails/bundle_report/cli.rb
@@ -3,7 +3,7 @@
 require "optparse"
 require "next_rails"
 require "next_rails/bundle_report"
-require 'byebug'
+require "byebug"
 
 class NextRails::BundleReport::CLI
   def initialize(argv)

--- a/lib/next_rails/bundle_report/cli.rb
+++ b/lib/next_rails/bundle_report/cli.rb
@@ -3,6 +3,7 @@
 require "optparse"
 require "next_rails"
 require "next_rails/bundle_report"
+require 'byebug'
 
 class NextRails::BundleReport::CLI
   def initialize(argv)
@@ -21,11 +22,11 @@ class NextRails::BundleReport::CLI
     end
 
     argv.each do |arg|
-      if arg.start_with?("--rails-version") && !arg.match?(/--rails-version=+\d+(\.\d+)*$/)
+      if arg.start_with?("--rails-version") && !/--rails-version=+\d+(\.\d+)*$/.match(arg)
         raise ArgumentError, "Invalid Rails version format. Example: --rails-version=5.0.7"
       end
 
-      if arg.start_with?("--ruby-version") && !arg.match?(/--ruby-version=+\d+(\.\d+)*$/)
+      if arg.start_with?("--ruby-version") && !/--ruby-version=+\d+(\.\d+)*$/.match(arg)
         raise ArgumentError, "Invalid Ruby version format. Example: --ruby-version=3.3"
       end
     end

--- a/next_rails.gemspec
+++ b/next_rails.gemspec
@@ -29,7 +29,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "simplecov", "~> 0.17.1"
   spec.add_development_dependency "timecop", "~> 0.9.1"
   spec.add_development_dependency "byebug"
-  spec.add_development_dependency "rexml", "3.3.8" # limited on purpose, new versions don't work with old rubies
+  spec.add_development_dependency "rexml", "3.2.5" # limited on purpose, new versions don't work with old rubies
   spec.add_development_dependency "webmock", "3.16.2"
   spec.add_development_dependency "base64"
 end

--- a/next_rails.gemspec
+++ b/next_rails.gemspec
@@ -30,5 +30,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "timecop", "~> 0.9.1"
   spec.add_development_dependency "byebug"
   spec.add_development_dependency "rexml", "3.3.8" # limited on purpose, new versions don't work with old rubies
-  spec.add_development_dependency "webmock", "3.20.0"
+  spec.add_development_dependency "webmock", "3.16.2"
+  spec.add_development_dependency "base64"
 end


### PR DESCRIPTION
## Description
This PR attempts to add back support of Ruby 2.3, 2.4, and 2.5 as requested in #135.

To add back the support for the older Ruby versions, I had to make the following changes:
- Several months ago, `rexml` was updated in this commit https://github.com/fastruby/next_rails/commit/e50e05a0d5e11124e48e8bfc89737e82f2c9bd83 . I had to downgrade it to 3.2.5, as 3.2.6 and above set Ruby 2.5 as the minimum requirement as seen in `rexml`’s `gemspec` https://github.com/ruby/rexml/commit/072b02fdcf4993e61cb39f4ed545f77e2f98d3d5.
- We added Ruby 3.4 support in February: https://github.com/fastruby/next_rails/commit/816e5b6434811fc766a0da2219b78b28598708aa by updating `webmock` to `3.20.0`. `webmock` version `3.20.0` is incompatible with Ruby versions below 2.5. To keep support for both Ruby 3.4 and Ruby 2.5 and below, I decided to downgrade `webmock` back to its' previous version and added `base64` as a dependency in the `gemspec`.
- We had a few instances of `match?`. `match?` wasn’t added until Ruby 2.4. I replaced those instances with `match`, which is also compatible with Ruby 2.3.


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
Ruby 2.3 and 2.4 have been added to the CI and the tests pass in all versions.

## Screenshots:
<!-- Add screenshots (applicable to any UI changes) -->

**I will abide by the [code of conduct](https://github.com/fastruby/next_rails/blob/main/CODE_OF_CONDUCT.md)**
