### PR TITLE
STJ-23: BUGFIX: deprecation_tracker breaking with unknown keywords #157

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 - [BUGFIX: example](https://github.com/fastruby/next_rails/pull/<number>)
 - [CHORE: Create an entry point for the BundleReport command](https://github.com/fastruby/next_rails/pull/154)
 - [CHORE: Bring back support of Ruby 2.3, 2.4 and 2.5](https://github.com/fastruby/next_rails/pull/155)
+- [BUFIX: deprecation_tracker breaking with unknown keywords](https://github.com/fastruby/next_rails/pull/158)
 
 * Your changes/patches go here.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 - [BUGFIX: example](https://github.com/fastruby/next_rails/pull/<number>)
 - [CHORE: Create an entry point for the BundleReport command](https://github.com/fastruby/next_rails/pull/154)
 - [CHORE: Bring back support of Ruby 2.3, 2.4 and 2.5](https://github.com/fastruby/next_rails/pull/155)
-- [BUFIX: deprecation_tracker breaking with unknown keywords](https://github.com/fastruby/next_rails/pull/158)
+- [BUGFIX: deprecation_tracker breaking with unknown keywords](https://github.com/fastruby/next_rails/pull/158)
 
 * Your changes/patches go here.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,10 +6,6 @@
 
 * Your changes/patches go here.
 
-# v1.4.7 / 2025-05-20 [(commits)](https://github.com/fastruby/next_rails/compare/v1.4.6...v1.4.7)
-
-- [BUFIX: deprecation_tracker breaking with unknown keywords](https://github.com/fastruby/next_rails/pull/156)
-
 # v1.4.6 / 2025-04-15 [(commits)](https://github.com/fastruby/next_rails/compare/v1.4.5...v1.4.6)
 
 - [BUFIX: Fix compatibilities performance bug](https://github.com/fastruby/next_rails/pull/150)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 * Your changes/patches go here.
 
+# v1.4.7 / 2025-05-20 [(commits)](https://github.com/fastruby/next_rails/compare/v1.4.6...v1.4.7)
+
+- [BUFIX: deprecation_tracker breaking with unknown keywords](https://github.com/fastruby/next_rails/pull/156)
+
 # v1.4.6 / 2025-04-15 [(commits)](https://github.com/fastruby/next_rails/compare/v1.4.5...v1.4.6)
 
 - [BUFIX: Fix compatibilities performance bug](https://github.com/fastruby/next_rails/pull/150)

--- a/lib/deprecation_tracker.rb
+++ b/lib/deprecation_tracker.rb
@@ -28,12 +28,14 @@ class DeprecationTracker
       keyword_args[:uplevel] = uplevel if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new("2.5.0")
       keyword_args[:category] = category if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new("3.2.0")
 
-      begin
-        # Combine known safe keywords with any extras
-        super(*messages, **keyword_args, **kwargs)
-      rescue ArgumentError
-        # Fallback: only pass known safe keywords
-        super(*messages, **keyword_args)
+      if keyword_args.empty?
+        super(*messages)
+      else
+        begin
+          super(*messages, **keyword_args, **kwargs)
+        rescue ArgumentError
+          super(*messages, **keyword_args)
+        end
       end
     end
   end

--- a/lib/deprecation_tracker.rb
+++ b/lib/deprecation_tracker.rb
@@ -18,7 +18,7 @@ class DeprecationTracker
       @callbacks ||= []
     end
 
-    def warn(*messages, uplevel: nil, category: nil)
+    def warn(*messages, uplevel: nil, category: nil, **kwargs)
       KernelWarnTracker.callbacks.each do |callback|
         messages.each { |message| callback.(message) }
       end
@@ -28,7 +28,11 @@ class DeprecationTracker
       elsif Gem::Version.new(RUBY_VERSION) < Gem::Version.new("3.0")
         super(*messages, uplevel: nil)
       else
-        super
+        begin
+          super(*messages, uplevel: uplevel, category: category, **kwargs)
+        rescue ArgumentError => e
+          super(*messages, uplevel: uplevel, category: category)
+        end
       end
     end
   end
@@ -43,7 +47,7 @@ class DeprecationTracker
           @@deprecation_tracker.bucket = test_file_name.gsub(Rails.root.to_s, ".")
           super
         end
-      
+
         def after_teardown
           super
           @@deprecation_tracker.bucket = nil

--- a/lib/deprecation_tracker.rb
+++ b/lib/deprecation_tracker.rb
@@ -28,11 +28,7 @@ class DeprecationTracker
       elsif Gem::Version.new(RUBY_VERSION) < Gem::Version.new("3.0")
         super(*messages, uplevel: nil)
       else
-        begin
-          super(*messages, uplevel: uplevel, category: category, **kwargs)
-        rescue ArgumentError => e
-          super(*messages, uplevel: uplevel, category: category)
-        end
+        super(*messages)
       end
     end
   end

--- a/lib/next_rails/version.rb
+++ b/lib/next_rails/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module NextRails
-  VERSION = "1.4.6"
+  VERSION = "1.4.7"
 end

--- a/spec/deprecation_tracker_spec.rb
+++ b/spec/deprecation_tracker_spec.rb
@@ -330,5 +330,15 @@ RSpec.describe DeprecationTracker do
         end
       end
     end
+
+    describe "bug when warning uses unexpected keyword arguments" do
+      it "does not raise an error with unknown keyword args like :deprecation, :span, :stack" do
+        DeprecationTracker::KernelWarnTracker.callbacks << -> (message) { message.to_s }
+
+        expect {
+          warn("Unknown deprecation warning", deprecation: true, span: 1.2, stack: ["line1", "line2"])
+        }.to not_raise_error.and output.to_stderr
+      end
+    end
   end
 end

--- a/spec/deprecation_tracker_spec.rb
+++ b/spec/deprecation_tracker_spec.rb
@@ -294,6 +294,8 @@ RSpec.describe DeprecationTracker do
   end
 
   describe DeprecationTracker::KernelWarnTracker do
+    before { DeprecationTracker::KernelWarnTracker.callbacks.clear }
+
     it "captures Kernel#warn" do
       warn_messages = []
       DeprecationTracker::KernelWarnTracker.callbacks << -> (message) { warn_messages << message }
@@ -340,5 +342,24 @@ RSpec.describe DeprecationTracker do
         }.to not_raise_error.and output.to_stderr
       end
     end
+
+    it "handles known and unknown keyword arguments without raising" do
+      warnings = []
+      DeprecationTracker::KernelWarnTracker.callbacks << ->(msg) { warnings << msg }
+
+      expect {
+        warn(
+          "This is a test warning",
+          uplevel: 1,
+          category: :deprecated,
+          deprecation: true,
+          span: 1.2,
+          stack: ["line"]
+        )
+      }.to not_raise_error
+
+      expect(warnings).to include("This is a test warning")
+    end
+
   end
 end


### PR DESCRIPTION
[STJ-23: BUGFIX: deprecation_tracker breaking with unknown keywords](https://ombulabs.atlassian.net/browse/STJ-23)

## Description

BUGFIX: Prevent DeprecationTracker from crashing when receiving unknown keyword arguments.

In certain environments (e.g. when using sass-embedded), the warn method receives unexpected keyword arguments such as :deprecation, :span, or :stack. Previously, these unrecognized keywords would raise an ArgumentError and interrupt execution. This patch safely handles unknown keyword arguments while preserving known ones.

## Motivation and Context
Fixes [#152](https://github.com/fastruby/next_rails/issues/152) — DeprecationTracker was breaking during setup in projects using sass-embedded due to unhandled keyword arguments in warn.

This update ensures that warn forwards all known and unknown keyword arguments safely to super, and gracefully falls back to known keywords if the parent method does not accept extras.


## How Has This Been Tested?

- Added a test to verify that warn can accept unknown keyword arguments (e.g. :deprecation, :span, :stack) without raising errors. 
- Ran the full test suite using Ruby 2.7 and Ruby 3.2 to ensure backward and forward compatibility.
- Verified that the warn method continues to capture and store deprecation messages as expected.

## Screenshots:
<!-- Add screenshots (applicable to any UI changes) -->

**I will abide by the [code of conduct](https://github.com/fastruby/next_rails/blob/main/CODE_OF_CONDUCT.md)**
