### PR TITLE
CI: Use actions/checkout@v4 to avoid deprecation warnings

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,7 +16,7 @@ jobs:
         ruby-version: ["3.4", "3.3", "3.2", "3.1", "3.0", "2.7", "2.6", "2.5", "2.4", "2.3"]
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Set up Ruby ${{ matrix.ruby-version }}
         uses: ruby/setup-ruby@v1
         with:


### PR DESCRIPTION
## Description

This PR changes how CI checks out code, updating the GitHub Action to the latest release.

## Motivation and Context

GitHub Actions deprecates old versions, displaying warnings as annotations.

## How Has This Been Tested?

I have not tested, I just know v4 is latest.

**I will abide by the [code of conduct](https://github.com/fastruby/next_rails/blob/main/CODE_OF_CONDUCT.md)**
