### PR TITLE
Add deprecations merge command to combine parallel CI shards

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 - [BUGFIX: example](https://github.com/fastruby/next_rails/pull/<number>)
 
+- [FEATURE: Add `deprecations merge` command to combine parallel CI shards](https://github.com/fastruby/next_rails/pull/177)
+- [FEATURE: Add parallel CI support for DeprecationTracker](https://github.com/fastruby/next_rails/pull/176)
+
 * Your changes/patches go here.
 
 # v1.5.0 / 2026-04-01 [(commits)](https://github.com/fastruby/next_rails/compare/v1.4.8...v1.5.0)

--- a/README.md
+++ b/README.md
@@ -179,9 +179,6 @@ deprecations merge --delete-shards
 
 # Or use --next to merge shards for the next Rails version
 deprecations merge --next --delete-shards
-
-# Use --path if your shitlist is in a custom location
-deprecations merge --path custom/path/shitlist.json --delete-shards
 ```
 
 You can also merge shards programmatically:

--- a/README.md
+++ b/README.md
@@ -161,10 +161,7 @@ RSpec.configure do |config|
   if ENV["DEPRECATION_TRACKER"]
     DeprecationTracker.track_rspec(
       config,
-      shitlist_path: "spec/support/deprecation_warning.shitlist.json",
-      mode: ENV["DEPRECATION_TRACKER"],
-      node_index: ENV["CI_NODE_INDEX"],
-      transform_message: -> (message) { message.gsub("#{Rails.root}/", "") }
+      node_index: ENV["CI_NODE_INDEX"]
     )
   end
 end

--- a/README.md
+++ b/README.md
@@ -150,6 +150,67 @@ DEPRECATION_TRACKER=save rspec
 DEPRECATION_TRACKER=compare rspec
 ```
 
+### Parallel CI support
+
+When running tests across parallel CI nodes, each node can write to its own shard file to avoid conflicts. The tracker auto-detects the node index from common CI environment variables (`CI_NODE_INDEX`, `CIRCLE_NODE_INDEX`, `BUILDKITE_PARALLEL_JOB`, `SEMAPHORE_JOB_INDEX`, `CI_NODE_INDEX` for GitLab), or you can set it explicitly via the `node_index` option.
+
+#### RSpec
+
+```ruby
+RSpec.configure do |config|
+  if ENV["DEPRECATION_TRACKER"]
+    DeprecationTracker.track_rspec(
+      config,
+      shitlist_path: "spec/support/deprecation_warning.shitlist.json",
+      mode: ENV["DEPRECATION_TRACKER"],
+      node_index: ENV["CI_NODE_INDEX"],
+      transform_message: -> (message) { message.gsub("#{Rails.root}/", "") }
+    )
+  end
+end
+```
+
+When `node_index` is set, the tracker writes to a shard file (e.g. `deprecation_warning.shitlist.node-0.json`) instead of the canonical file.
+
+#### Merging shards
+
+After all parallel nodes finish saving, merge shards into the canonical file:
+
+```bash
+# Merge all shard files and remove them afterwards
+deprecations merge --delete-shards
+
+# Or use --next to merge shards for the next Rails version
+deprecations merge --next --delete-shards
+
+# Use --path if your shitlist is in a custom location
+deprecations merge --path custom/path/shitlist.json --delete-shards
+```
+
+You can also merge shards programmatically:
+
+```ruby
+DeprecationTracker.merge_shards(
+  "spec/support/deprecation_warning.shitlist.json",
+  delete_shards: true
+)
+```
+
+#### Example CI workflow
+
+```yaml
+# 1. Save phase — each parallel node writes its own shard
+#    (runs on every node)
+DEPRECATION_TRACKER=save CI_NODE_INDEX=$NODE bundle exec rspec <subset>
+
+# 2. Merge phase — fan-in step, runs once after all nodes finish
+deprecations merge --delete-shards
+
+# 3. Compare phase — each parallel node checks its buckets
+#    against the merged canonical file
+DEPRECATION_TRACKER=compare CI_NODE_INDEX=$NODE bundle exec rspec <subset>
+```
+
 ### `deprecations` command
 
 View, filter, and manage stored deprecation warnings:
@@ -157,6 +218,7 @@ View, filter, and manage stored deprecation warnings:
 ```bash
 deprecations info
 deprecations info --pattern "ActiveRecord::Base"
+deprecations merge --delete-shards
 deprecations run
 deprecations --help
 ```

--- a/exe/deprecations
+++ b/exe/deprecations
@@ -49,6 +49,8 @@ option_parser = OptionParser.new do |opts|
       bin/deprecations --next info # Show top ten deprecations for Rails 5
       bin/deprecations --pattern "ActiveRecord::Base" --verbose info # Show full details on deprecations matching pattern
       bin/deprecations --tracker-mode save --pattern "pass" run # Run tests that output deprecations matching pattern and update shitlist
+      bin/deprecations merge --delete-shards # Merge parallel CI shards and remove shard files
+      bin/deprecations --path custom/path/shitlist.json merge # Merge shards at a custom path
 
     Modes:
       info
@@ -56,6 +58,9 @@ option_parser = OptionParser.new do |opts|
 
       run
         Run tests that are known to cause deprecation warnings. Use --pattern to filter what tests are run.
+
+      merge
+        Merge parallel CI shard files into the canonical shitlist. Use with --delete-shards to remove shard files after merging.
 
     Options:
   MESSAGE
@@ -76,6 +81,14 @@ option_parser = OptionParser.new do |opts|
     options[:verbose] = true
   end
 
+  opts.on("--delete-shards", "Delete shard files after merging") do
+    options[:delete_shards] = true
+  end
+
+  opts.on("--path PATH", "Path to the shitlist file (overrides default and --next)") do |path|
+    options[:path] = path
+  end
+
   opts.on_tail("-h", "--help", "Prints this help") do
     puts opts
     exit
@@ -85,7 +98,23 @@ end
 option_parser.parse!
 
 options[:mode] = ARGV.last
-path = options[:next] ? "spec/support/deprecation_warning.next.shitlist.json" : "spec/support/deprecation_warning.shitlist.json"
+path = if options[:path]
+  options[:path]
+elsif options[:next]
+  "spec/support/deprecation_warning.next.shitlist.json"
+else
+  "spec/support/deprecation_warning.shitlist.json"
+end
+
+if options[:mode] == "merge"
+  require_relative "../lib/deprecation_tracker/shard_merger"
+  output = DeprecationTracker::ShardMerger.new(path).merge(delete_shards: !!options[:delete_shards])
+  shards = output[:shards]
+  result = output[:result]
+  total_messages = result.values.map(&:size).reduce(0, :+)
+  puts "Merged #{shards} shard files into #{path} (#{result.size} test files, #{total_messages} deprecation messages)"
+  exit 0
+end
 
 pattern_string = options.fetch(:pattern, ".+")
 pattern = /#{pattern_string}/

--- a/exe/deprecations
+++ b/exe/deprecations
@@ -3,6 +3,7 @@ require "json"
 require "rainbow"
 require "optparse"
 require "set"
+require_relative "../lib/deprecation_tracker/shard_merger"
 
 def run_tests(deprecation_warnings, opts = {})
   tracker_mode = opts[:tracker_mode]
@@ -95,34 +96,34 @@ option_parser.parse!
 options[:mode] = ARGV.last
 path = options[:next] ? "spec/support/deprecation_warning.next.shitlist.json" : "spec/support/deprecation_warning.shitlist.json"
 
-if options[:mode] == "merge"
-  require_relative "../lib/deprecation_tracker/shard_merger"
+case options[:mode]
+when "merge"
   output = DeprecationTracker::ShardMerger.new(path, delete_shards: !!options[:delete_shards]).merge
   shards = output[:shards]
   result = output[:result]
   total_messages = result.values.map(&:size).reduce(0, :+)
   puts "Merged #{shards} shard files into #{path} (#{result.size} buckets, #{total_messages} deprecation messages)"
-  exit 0
-end
+when "run", "info"
+  pattern_string = options.fetch(:pattern, ".+")
+  pattern = /#{pattern_string}/
 
-pattern_string = options.fetch(:pattern, ".+")
-pattern = /#{pattern_string}/
+  deprecation_warnings = JSON.parse(File.read(path)).each_with_object({}) do |(test_file, messages), hash|
+    filtered_messages = messages.select {|message| message.match(pattern) }
+    hash[test_file] = filtered_messages if !filtered_messages.empty?
+  end
 
-deprecation_warnings = JSON.parse(File.read(path)).each_with_object({}) do |(test_file, messages), hash|
-  filtered_messages = messages.select {|message| message.match(pattern) }
-  hash[test_file] = filtered_messages if !filtered_messages.empty?
-end
+  if deprecation_warnings.empty?
+    abort "No test files with deprecations matching #{pattern.inspect}."
+    exit 2
+  end
 
-if deprecation_warnings.empty?
-  abort "No test files with deprecations matching #{pattern.inspect}."
-  exit 2
-end
-
-case options.fetch(:mode, "info")
-when "run" then run_tests(deprecation_warnings, next_mode: options[:next], tracker_mode: options[:tracker_mode])
-when "info" then print_info(deprecation_warnings, verbose: options[:verbose])
+  if options[:mode] == "run"
+    run_tests(deprecation_warnings, next_mode: options[:next], tracker_mode: options[:tracker_mode])
+  else
+    print_info(deprecation_warnings, verbose: options[:verbose])
+  end
 when nil
-  STDERR.puts Rainbow("Must pass a mode: run or info").red
+  STDERR.puts Rainbow("Must pass a mode: run, info, or merge").red
   puts option_parser
   exit 1
 else

--- a/exe/deprecations
+++ b/exe/deprecations
@@ -50,7 +50,6 @@ option_parser = OptionParser.new do |opts|
       bin/deprecations --pattern "ActiveRecord::Base" --verbose info # Show full details on deprecations matching pattern
       bin/deprecations --tracker-mode save --pattern "pass" run # Run tests that output deprecations matching pattern and update shitlist
       bin/deprecations merge --delete-shards # Merge parallel CI shards and remove shard files
-      bin/deprecations --path custom/path/shitlist.json merge # Merge shards at a custom path
 
     Modes:
       info
@@ -85,10 +84,6 @@ option_parser = OptionParser.new do |opts|
     options[:delete_shards] = true
   end
 
-  opts.on("--path PATH", "Path to the shitlist file (overrides default and --next)") do |path|
-    options[:path] = path
-  end
-
   opts.on_tail("-h", "--help", "Prints this help") do
     puts opts
     exit
@@ -98,21 +93,15 @@ end
 option_parser.parse!
 
 options[:mode] = ARGV.last
-path = if options[:path]
-  options[:path]
-elsif options[:next]
-  "spec/support/deprecation_warning.next.shitlist.json"
-else
-  "spec/support/deprecation_warning.shitlist.json"
-end
+path = options[:next] ? "spec/support/deprecation_warning.next.shitlist.json" : "spec/support/deprecation_warning.shitlist.json"
 
 if options[:mode] == "merge"
   require_relative "../lib/deprecation_tracker/shard_merger"
-  output = DeprecationTracker::ShardMerger.new(path).merge(delete_shards: !!options[:delete_shards])
+  output = DeprecationTracker::ShardMerger.new(path, delete_shards: !!options[:delete_shards]).merge
   shards = output[:shards]
   result = output[:result]
   total_messages = result.values.map(&:size).reduce(0, :+)
-  puts "Merged #{shards} shard files into #{path} (#{result.size} test files, #{total_messages} deprecation messages)"
+  puts "Merged #{shards} shard files into #{path} (#{result.size} buckets, #{total_messages} deprecation messages)"
   exit 0
 end
 

--- a/lib/deprecation_tracker.rb
+++ b/lib/deprecation_tracker.rb
@@ -131,7 +131,7 @@ class DeprecationTracker
 
   def self.merge_shards(base_path, delete_shards: false)
     require_relative "deprecation_tracker/shard_merger"
-    ShardMerger.new(base_path).merge(delete_shards: delete_shards)[:result]
+    ShardMerger.new(base_path, delete_shards: delete_shards).merge[:result]
   end
 
   attr_reader :deprecation_messages, :shitlist_path, :transform_message, :bucket, :mode, :node_index

--- a/lib/deprecation_tracker.rb
+++ b/lib/deprecation_tracker.rb
@@ -129,6 +129,11 @@ class DeprecationTracker
     ActiveSupport::TestCase.include(MinitestExtension.new(tracker))
   end
 
+  def self.merge_shards(base_path, delete_shards: false)
+    require_relative "deprecation_tracker/shard_merger"
+    ShardMerger.new(base_path).merge(delete_shards: delete_shards)[:result]
+  end
+
   attr_reader :deprecation_messages, :shitlist_path, :transform_message, :bucket, :mode, :node_index
 
   def initialize(shitlist_path, transform_message = nil, mode = :save, node_index: nil)

--- a/lib/deprecation_tracker/shard_merger.rb
+++ b/lib/deprecation_tracker/shard_merger.rb
@@ -1,0 +1,43 @@
+require "json"
+require "fileutils"
+
+class DeprecationTracker
+  class ShardMerger
+    attr_reader :base_path
+
+    def initialize(base_path)
+      @base_path = base_path
+    end
+
+    def merge(delete_shards: false)
+      shard_files = Dir.glob(shard_glob).sort
+
+      merged = {}
+      shard_files.each do |file|
+        JSON.parse(File.read(file)).each do |bucket, messages|
+          merged[bucket] = (merged[bucket] || []).concat(Array(messages))
+        end
+      end
+
+      result = {}
+      merged.sort.each do |k, v|
+        result[k] = v.sort
+      end
+
+      dirname = File.dirname(base_path)
+      FileUtils.mkdir_p(dirname) unless File.directory?(dirname)
+      File.write(base_path, JSON.pretty_generate(result))
+
+      shard_files.each { |f| File.delete(f) } if delete_shards
+
+      { shards: shard_files.size, result: result }
+    end
+
+    private
+
+    def shard_glob
+      ext = File.extname(base_path)
+      "#{base_path.chomp(ext)}.node-*#{ext}"
+    end
+  end
+end

--- a/lib/deprecation_tracker/shard_merger.rb
+++ b/lib/deprecation_tracker/shard_merger.rb
@@ -3,18 +3,19 @@ require "fileutils"
 
 class DeprecationTracker
   class ShardMerger
-    attr_reader :base_path
+    attr_reader :base_path, :delete_shards
 
-    def initialize(base_path)
+    def initialize(base_path, delete_shards: false)
       @base_path = base_path
+      @delete_shards = delete_shards
     end
 
-    def merge(delete_shards: false)
+    def merge
       shard_files = Dir.glob(shard_glob).sort
 
       merged = {}
       shard_files.each do |file|
-        JSON.parse(File.read(file)).each do |bucket, messages|
+        parse_shard(file).each do |bucket, messages|
           merged[bucket] = (merged[bucket] || []).concat(Array(messages))
         end
       end
@@ -26,7 +27,12 @@ class DeprecationTracker
 
       dirname = File.dirname(base_path)
       FileUtils.mkdir_p(dirname) unless File.directory?(dirname)
-      File.write(base_path, JSON.pretty_generate(result))
+
+      begin
+        File.write(base_path, JSON.pretty_generate(result))
+      rescue Errno::EACCES => e
+        raise "Cannot write to #{base_path}: #{e.message}"
+      end
 
       shard_files.each { |f| File.delete(f) } if delete_shards
 
@@ -38,6 +44,14 @@ class DeprecationTracker
     def shard_glob
       ext = File.extname(base_path)
       "#{base_path.chomp(ext)}.node-*#{ext}"
+    end
+
+    def parse_shard(file)
+      JSON.parse(File.read(file))
+    rescue Errno::ENOENT
+      raise "Shard file not found: #{file}"
+    rescue JSON::ParserError => e
+      raise "Invalid JSON in shard file #{file}: #{e.message}"
     end
   end
 end

--- a/lib/deprecation_tracker/shard_merger.rb
+++ b/lib/deprecation_tracker/shard_merger.rb
@@ -11,7 +11,18 @@ class DeprecationTracker
     end
 
     def merge
+      dirname = File.dirname(base_path)
+      unless File.directory?(dirname)
+        warn "Directory does not exist: #{dirname}"
+        return { shards: 0, result: {} }
+      end
+
       shard_files = Dir.glob(shard_glob).sort
+
+      if shard_files.empty?
+        warn "No shards found at #{shard_glob}"
+        return { shards: 0, result: {} }
+      end
 
       merged = {}
       shard_files.each do |file|
@@ -24,9 +35,6 @@ class DeprecationTracker
       merged.sort.each do |k, v|
         result[k] = v.sort
       end
-
-      dirname = File.dirname(base_path)
-      FileUtils.mkdir_p(dirname) unless File.directory?(dirname)
 
       begin
         File.write(base_path, JSON.pretty_generate(result))
@@ -42,8 +50,7 @@ class DeprecationTracker
     private
 
     def shard_glob
-      ext = File.extname(base_path)
-      "#{base_path.chomp(ext)}.node-*#{ext}"
+      "#{base_path.chomp('.json')}.node-*.json"
     end
 
     def parse_shard(file)

--- a/spec/deprecation_tracker_spec.rb
+++ b/spec/deprecation_tracker_spec.rb
@@ -5,7 +5,6 @@ require "spec_helper"
 require "date"
 require "tempfile"
 require_relative "../lib/deprecation_tracker"
-require_relative "../lib/deprecation_tracker/shard_merger"
 
 RSpec::Matchers.define_negated_matcher :not_raise_error, :raise_error
 
@@ -429,95 +428,6 @@ RSpec.describe DeprecationTracker do
       result = DeprecationTracker.merge_shards(base_path)
 
       expect(result).to eq("bucket 1" => ["a"])
-    end
-  end
-
-  describe DeprecationTracker::ShardMerger do
-    let(:base_path) { Tempfile.new("shitlist").path }
-    let(:ext) { File.extname(base_path) }
-    let(:shard_prefix) { base_path.chomp(ext) }
-
-    after do
-      FileUtils.rm_f(base_path)
-      Dir.glob("#{shard_prefix}.node-*#{ext}").each { |f| FileUtils.rm_f(f) }
-    end
-
-    def write_shard(index, data)
-      path = "#{shard_prefix}.node-#{index}#{ext}"
-      File.write(path, JSON.pretty_generate(data))
-      path
-    end
-
-    subject { described_class.new(base_path) }
-
-    it "merges multiple shard files into the canonical file" do
-      write_shard(0, { "bucket 1" => ["a"], "bucket 2" => ["b"] })
-      write_shard(1, { "bucket 3" => ["c"] })
-
-      output = subject.merge
-      result = output[:result]
-
-      expect(result).to eq(
-        "bucket 1" => ["a"],
-        "bucket 2" => ["b"],
-        "bucket 3" => ["c"]
-      )
-      expect(output[:shards]).to eq(2)
-      expect(JSON.parse(File.read(base_path))).to eq(result)
-    end
-
-    it "deep-merges overlapping buckets by concatenating and sorting messages" do
-      write_shard(0, { "bucket 1" => ["b", "a"] })
-      write_shard(1, { "bucket 1" => ["c", "a"] })
-
-      result = subject.merge[:result]
-
-      expect(result).to eq("bucket 1" => ["a", "a", "b", "c"])
-    end
-
-    it "returns an empty hash and writes empty JSON when no shards exist" do
-      output = subject.merge
-
-      expect(output[:result]).to eq({})
-      expect(output[:shards]).to eq(0)
-      expect(JSON.parse(File.read(base_path))).to eq({})
-    end
-
-    it "handles a single shard file" do
-      write_shard(0, { "bucket 1" => ["a"] })
-
-      output = subject.merge
-
-      expect(output[:result]).to eq("bucket 1" => ["a"])
-      expect(output[:shards]).to eq(1)
-    end
-
-    it "deletes shard files when delete_shards is true" do
-      shard0 = write_shard(0, { "bucket 1" => ["a"] })
-      shard1 = write_shard(1, { "bucket 2" => ["b"] })
-
-      subject.merge(delete_shards: true)
-
-      expect(File.exist?(shard0)).to be false
-      expect(File.exist?(shard1)).to be false
-      expect(File.exist?(base_path)).to be true
-    end
-
-    it "preserves shard files when delete_shards is false" do
-      shard0 = write_shard(0, { "bucket 1" => ["a"] })
-
-      subject.merge(delete_shards: false)
-
-      expect(File.exist?(shard0)).to be true
-    end
-
-    it "sorts buckets alphabetically" do
-      write_shard(0, { "z_bucket" => ["a"] })
-      write_shard(1, { "a_bucket" => ["b"] })
-
-      result = subject.merge[:result]
-
-      expect(result.keys).to eq(["a_bucket", "z_bucket"])
     end
   end
 

--- a/spec/deprecation_tracker_spec.rb
+++ b/spec/deprecation_tracker_spec.rb
@@ -5,6 +5,7 @@ require "spec_helper"
 require "date"
 require "tempfile"
 require_relative "../lib/deprecation_tracker"
+require_relative "../lib/deprecation_tracker/shard_merger"
 
 RSpec::Matchers.define_negated_matcher :not_raise_error, :raise_error
 
@@ -403,6 +404,120 @@ RSpec.describe DeprecationTracker do
       stub_const("ENV", ENV.to_h.merge("DEPRECATION_TRACKER" => "compare"))
       tracker = DeprecationTracker.init_tracker({})
       expect(tracker.mode).to eq(:compare)
+    end
+  end
+
+  describe ".merge_shards" do
+    let(:base_path) { Tempfile.new("shitlist").path }
+    let(:ext) { File.extname(base_path) }
+    let(:shard_prefix) { base_path.chomp(ext) }
+
+    after do
+      FileUtils.rm_f(base_path)
+      Dir.glob("#{shard_prefix}.node-*#{ext}").each { |f| FileUtils.rm_f(f) }
+    end
+
+    def write_shard(index, data)
+      path = "#{shard_prefix}.node-#{index}#{ext}"
+      File.write(path, JSON.pretty_generate(data))
+      path
+    end
+
+    it "delegates to ShardMerger" do
+      write_shard(0, { "bucket 1" => ["a"] })
+
+      result = DeprecationTracker.merge_shards(base_path)
+
+      expect(result).to eq("bucket 1" => ["a"])
+    end
+  end
+
+  describe DeprecationTracker::ShardMerger do
+    let(:base_path) { Tempfile.new("shitlist").path }
+    let(:ext) { File.extname(base_path) }
+    let(:shard_prefix) { base_path.chomp(ext) }
+
+    after do
+      FileUtils.rm_f(base_path)
+      Dir.glob("#{shard_prefix}.node-*#{ext}").each { |f| FileUtils.rm_f(f) }
+    end
+
+    def write_shard(index, data)
+      path = "#{shard_prefix}.node-#{index}#{ext}"
+      File.write(path, JSON.pretty_generate(data))
+      path
+    end
+
+    subject { described_class.new(base_path) }
+
+    it "merges multiple shard files into the canonical file" do
+      write_shard(0, { "bucket 1" => ["a"], "bucket 2" => ["b"] })
+      write_shard(1, { "bucket 3" => ["c"] })
+
+      output = subject.merge
+      result = output[:result]
+
+      expect(result).to eq(
+        "bucket 1" => ["a"],
+        "bucket 2" => ["b"],
+        "bucket 3" => ["c"]
+      )
+      expect(output[:shards]).to eq(2)
+      expect(JSON.parse(File.read(base_path))).to eq(result)
+    end
+
+    it "deep-merges overlapping buckets by concatenating and sorting messages" do
+      write_shard(0, { "bucket 1" => ["b", "a"] })
+      write_shard(1, { "bucket 1" => ["c", "a"] })
+
+      result = subject.merge[:result]
+
+      expect(result).to eq("bucket 1" => ["a", "a", "b", "c"])
+    end
+
+    it "returns an empty hash and writes empty JSON when no shards exist" do
+      output = subject.merge
+
+      expect(output[:result]).to eq({})
+      expect(output[:shards]).to eq(0)
+      expect(JSON.parse(File.read(base_path))).to eq({})
+    end
+
+    it "handles a single shard file" do
+      write_shard(0, { "bucket 1" => ["a"] })
+
+      output = subject.merge
+
+      expect(output[:result]).to eq("bucket 1" => ["a"])
+      expect(output[:shards]).to eq(1)
+    end
+
+    it "deletes shard files when delete_shards is true" do
+      shard0 = write_shard(0, { "bucket 1" => ["a"] })
+      shard1 = write_shard(1, { "bucket 2" => ["b"] })
+
+      subject.merge(delete_shards: true)
+
+      expect(File.exist?(shard0)).to be false
+      expect(File.exist?(shard1)).to be false
+      expect(File.exist?(base_path)).to be true
+    end
+
+    it "preserves shard files when delete_shards is false" do
+      shard0 = write_shard(0, { "bucket 1" => ["a"] })
+
+      subject.merge(delete_shards: false)
+
+      expect(File.exist?(shard0)).to be true
+    end
+
+    it "sorts buckets alphabetically" do
+      write_shard(0, { "z_bucket" => ["a"] })
+      write_shard(1, { "a_bucket" => ["b"] })
+
+      result = subject.merge[:result]
+
+      expect(result.keys).to eq(["a_bucket", "z_bucket"])
     end
   end
 

--- a/spec/deprecation_tracker_spec.rb
+++ b/spec/deprecation_tracker_spec.rb
@@ -407,27 +407,17 @@ RSpec.describe DeprecationTracker do
   end
 
   describe ".merge_shards" do
-    let(:base_path) { Tempfile.new("shitlist").path }
-    let(:ext) { File.extname(base_path) }
-    let(:shard_prefix) { base_path.chomp(ext) }
-
-    after do
-      FileUtils.rm_f(base_path)
-      Dir.glob("#{shard_prefix}.node-*#{ext}").each { |f| FileUtils.rm_f(f) }
-    end
-
-    def write_shard(index, data)
-      path = "#{shard_prefix}.node-#{index}#{ext}"
-      File.write(path, JSON.pretty_generate(data))
-      path
-    end
-
     it "delegates to ShardMerger" do
-      write_shard(0, { "bucket 1" => ["a"] })
+      merger = instance_double(DeprecationTracker::ShardMerger)
+      expect(DeprecationTracker::ShardMerger).to receive(:new)
+        .with("some/path.json", delete_shards: true)
+        .and_return(merger)
+      expect(merger).to receive(:merge)
+        .and_return({ shards: 1, result: { "bucket" => ["a"] } })
 
-      result = DeprecationTracker.merge_shards(base_path)
+      result = DeprecationTracker.merge_shards("some/path.json", delete_shards: true)
 
-      expect(result).to eq("bucket 1" => ["a"])
+      expect(result).to eq("bucket" => ["a"])
     end
   end
 

--- a/spec/deprecation_tracker_spec.rb
+++ b/spec/deprecation_tracker_spec.rb
@@ -406,21 +406,6 @@ RSpec.describe DeprecationTracker do
     end
   end
 
-  describe ".merge_shards" do
-    it "delegates to ShardMerger" do
-      merger = instance_double(DeprecationTracker::ShardMerger)
-      expect(DeprecationTracker::ShardMerger).to receive(:new)
-        .with("some/path.json", delete_shards: true)
-        .and_return(merger)
-      expect(merger).to receive(:merge)
-        .and_return({ shards: 1, result: { "bucket" => ["a"] } })
-
-      result = DeprecationTracker.merge_shards("some/path.json", delete_shards: true)
-
-      expect(result).to eq("bucket" => ["a"])
-    end
-  end
-
   describe DeprecationTracker::KernelWarnTracker do
     before { DeprecationTracker::KernelWarnTracker.callbacks.clear }
 

--- a/spec/shard_merger_spec.rb
+++ b/spec/shard_merger_spec.rb
@@ -50,12 +50,25 @@ RSpec.describe DeprecationTracker::ShardMerger do
     expect(result).to eq("bucket 1" => ["a", "a", "b", "c"])
   end
 
-  it "returns an empty hash and writes empty JSON when no shards exist" do
+  it "warns and returns empty result when no shards exist" do
+    expect { output = subject.merge }.to output(/No shards found/).to_stderr
+
     output = subject.merge
 
     expect(output[:result]).to eq({})
     expect(output[:shards]).to eq(0)
-    expect(JSON.parse(File.read(base_path))).to eq({})
+    expect(File.exist?(base_path)).to be false
+  end
+
+  it "warns and returns empty result when directory does not exist" do
+    merger = described_class.new("/nonexistent/path/shitlist.json")
+
+    expect { output = merger.merge }.to output(/Directory does not exist/).to_stderr
+
+    output = merger.merge
+
+    expect(output[:result]).to eq({})
+    expect(output[:shards]).to eq(0)
   end
 
   it "handles a single shard file" do

--- a/spec/shard_merger_spec.rb
+++ b/spec/shard_merger_spec.rb
@@ -7,17 +7,18 @@ require "tempfile"
 require_relative "../lib/deprecation_tracker/shard_merger"
 
 RSpec.describe DeprecationTracker::ShardMerger do
-  let(:base_path) { Tempfile.new("shitlist").path }
-  let(:ext) { File.extname(base_path) }
-  let(:shard_prefix) { base_path.chomp(ext) }
+  let(:base_path) do
+    dir = Dir.tmpdir
+    File.join(dir, "shitlist-#{Process.pid}-#{rand(1000)}.json")
+  end
 
   after do
     FileUtils.rm_f(base_path)
-    Dir.glob("#{shard_prefix}.node-*#{ext}").each { |f| FileUtils.rm_f(f) }
+    Dir.glob("#{base_path.chomp('.json')}.node-*.json").each { |f| FileUtils.rm_f(f) }
   end
 
   def write_shard(index, data)
-    path = "#{shard_prefix}.node-#{index}#{ext}"
+    path = "#{base_path.chomp('.json')}.node-#{index}.json"
     File.write(path, JSON.pretty_generate(data))
     path
   end
@@ -70,17 +71,18 @@ RSpec.describe DeprecationTracker::ShardMerger do
     shard0 = write_shard(0, { "bucket 1" => ["a"] })
     shard1 = write_shard(1, { "bucket 2" => ["b"] })
 
-    subject.merge(delete_shards: true)
+    merger = described_class.new(base_path, delete_shards: true)
+    merger.merge
 
     expect(File.exist?(shard0)).to be false
     expect(File.exist?(shard1)).to be false
     expect(File.exist?(base_path)).to be true
   end
 
-  it "preserves shard files when delete_shards is false" do
+  it "preserves shard files by default" do
     shard0 = write_shard(0, { "bucket 1" => ["a"] })
 
-    subject.merge(delete_shards: false)
+    subject.merge
 
     expect(File.exist?(shard0)).to be true
   end
@@ -92,5 +94,12 @@ RSpec.describe DeprecationTracker::ShardMerger do
     result = subject.merge[:result]
 
     expect(result.keys).to eq(["a_bucket", "z_bucket"])
+  end
+
+  it "raises an error for invalid JSON in a shard file" do
+    shard_path = "#{base_path.chomp('.json')}.node-0.json"
+    File.write(shard_path, "not valid json")
+
+    expect { subject.merge }.to raise_error(/Invalid JSON in shard file/)
   end
 end

--- a/spec/shard_merger_spec.rb
+++ b/spec/shard_merger_spec.rb
@@ -1,0 +1,96 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+require "json"
+require "tempfile"
+require_relative "../lib/deprecation_tracker/shard_merger"
+
+RSpec.describe DeprecationTracker::ShardMerger do
+  let(:base_path) { Tempfile.new("shitlist").path }
+  let(:ext) { File.extname(base_path) }
+  let(:shard_prefix) { base_path.chomp(ext) }
+
+  after do
+    FileUtils.rm_f(base_path)
+    Dir.glob("#{shard_prefix}.node-*#{ext}").each { |f| FileUtils.rm_f(f) }
+  end
+
+  def write_shard(index, data)
+    path = "#{shard_prefix}.node-#{index}#{ext}"
+    File.write(path, JSON.pretty_generate(data))
+    path
+  end
+
+  subject { described_class.new(base_path) }
+
+  it "merges multiple shard files into the canonical file" do
+    write_shard(0, { "bucket 1" => ["a"], "bucket 2" => ["b"] })
+    write_shard(1, { "bucket 3" => ["c"] })
+
+    output = subject.merge
+    result = output[:result]
+
+    expect(result).to eq(
+      "bucket 1" => ["a"],
+      "bucket 2" => ["b"],
+      "bucket 3" => ["c"]
+    )
+    expect(output[:shards]).to eq(2)
+    expect(JSON.parse(File.read(base_path))).to eq(result)
+  end
+
+  it "deep-merges overlapping buckets by concatenating and sorting messages" do
+    write_shard(0, { "bucket 1" => ["b", "a"] })
+    write_shard(1, { "bucket 1" => ["c", "a"] })
+
+    result = subject.merge[:result]
+
+    expect(result).to eq("bucket 1" => ["a", "a", "b", "c"])
+  end
+
+  it "returns an empty hash and writes empty JSON when no shards exist" do
+    output = subject.merge
+
+    expect(output[:result]).to eq({})
+    expect(output[:shards]).to eq(0)
+    expect(JSON.parse(File.read(base_path))).to eq({})
+  end
+
+  it "handles a single shard file" do
+    write_shard(0, { "bucket 1" => ["a"] })
+
+    output = subject.merge
+
+    expect(output[:result]).to eq("bucket 1" => ["a"])
+    expect(output[:shards]).to eq(1)
+  end
+
+  it "deletes shard files when delete_shards is true" do
+    shard0 = write_shard(0, { "bucket 1" => ["a"] })
+    shard1 = write_shard(1, { "bucket 2" => ["b"] })
+
+    subject.merge(delete_shards: true)
+
+    expect(File.exist?(shard0)).to be false
+    expect(File.exist?(shard1)).to be false
+    expect(File.exist?(base_path)).to be true
+  end
+
+  it "preserves shard files when delete_shards is false" do
+    shard0 = write_shard(0, { "bucket 1" => ["a"] })
+
+    subject.merge(delete_shards: false)
+
+    expect(File.exist?(shard0)).to be true
+  end
+
+  it "sorts buckets alphabetically" do
+    write_shard(0, { "z_bucket" => ["a"] })
+    write_shard(1, { "a_bucket" => ["b"] })
+
+    result = subject.merge[:result]
+
+    expect(result.keys).to eq(["a_bucket", "z_bucket"])
+  end
+end


### PR DESCRIPTION
## Summary

Adds a `deprecations merge` CLI command and `DeprecationTracker::ShardMerger` class to combine shard files produced by parallel CI nodes into a single canonical shitlist file.

This is the companion to #176 (parallel CI support). When each CI node writes its own shard (e.g. `deprecation_warning.shitlist.node-0.json`), a fan-in step is needed to merge them before the compare phase.

## Changes

- **`DeprecationTracker::ShardMerger`** — new class in `lib/deprecation_tracker/shard_merger.rb` with deep-merge logic (concatenates arrays for overlapping buckets), fixing the data loss bug from #83 where `inject(:merge)` silently dropped warnings when multiple shards shared the same keys.
- **`deprecations merge` CLI subcommand** — with `--delete-shards` to clean up after merging and `--next` for the next Rails shitlist.
- **`DeprecationTracker.merge_shards`** — convenience class method that delegates to `ShardMerger`.
- **Error handling** — clear messages for missing shard files, invalid JSON, and write permission errors.
- **8 specs** in dedicated `spec/shard_merger_spec.rb` covering: multiple shards, overlapping buckets, no shards, single shard, delete/preserve shards, sort order, and invalid JSON.
- **README** updated with parallel CI docs, merge command usage, and example CI workflow.
- **CHANGELOG** updated for both #176 and this PR.

### Example CI workflow

```yaml
# 1. Save phase (each parallel node)
DEPRECATION_TRACKER=save CI_NODE_INDEX=$NODE bundle exec rspec <subset>

# 2. Merge phase (fan-in, runs once)
deprecations merge --delete-shards

# 3. Compare phase (each parallel node)
DEPRECATION_TRACKER=compare CI_NODE_INDEX=$NODE bundle exec rspec <subset>
```

## Test plan

- [x] `bundle exec rspec spec/deprecation_tracker_spec.rb spec/shard_merger_spec.rb` — 42 examples, 0 failures
- [x] Manual test with 3 shard files containing overlapping buckets — all deprecation messages preserved
- [x] `--delete-shards` removes shard files, canonical file remains
- [x] CI passes
