### PR TITLE
Fix compare mode to not check node bucket files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 - [BUGFIX: example](https://github.com/fastruby/next_rails/pull/<number>)
 
-- [BUGFIX: Compare mode now checks only buckets the current process ran, fixing parallel test support](https://github.com/fastruby/next_rails/pull/<number>)
+- [BUGFIX: Compare mode now checks only buckets the current process ran, fixing parallel test support](https://github.com/fastruby/next_rails/pull/179)
 - [FEATURE: Add `deprecations merge` command to combine parallel CI shards](https://github.com/fastruby/next_rails/pull/177)
 - [FEATURE: Add parallel CI support for DeprecationTracker](https://github.com/fastruby/next_rails/pull/176)
 - [CHORE: Add Ruby 4.0 to the test matrix](https://github.com/fastruby/next_rails/pull/178)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - [BUGFIX: example](https://github.com/fastruby/next_rails/pull/<number>)
 
+- [BUGFIX: Compare mode now checks only buckets the current process ran, fixing parallel test support](https://github.com/fastruby/next_rails/pull/<number>)
 - [FEATURE: Add `deprecations merge` command to combine parallel CI shards](https://github.com/fastruby/next_rails/pull/177)
 - [FEATURE: Add parallel CI support for DeprecationTracker](https://github.com/fastruby/next_rails/pull/176)
 - [CHORE: Add Ruby 4.0 to the test matrix](https://github.com/fastruby/next_rails/pull/178)

--- a/README.md
+++ b/README.md
@@ -167,7 +167,7 @@ RSpec.configure do |config|
 end
 ```
 
-The `node_index` option is only used in save mode. When set, the tracker writes to a shard file (e.g. `deprecation_warning.shitlist.node-0.json`) instead of the canonical file. In compare mode, `node_index` is not needed because the tracker automatically checks only the buckets that the current process ran.
+The `node_index` option is only used in save mode. When set, the tracker writes to a shard file (e.g. `deprecation_warning.shitlist.node-0.json`) instead of the canonical file. Compare mode does not support `node_index` and will raise an error if passed—compare should only run after merging shards on the final canonical shitlist.
 
 #### Merging shards
 

--- a/README.md
+++ b/README.md
@@ -167,7 +167,7 @@ RSpec.configure do |config|
 end
 ```
 
-When `node_index` is set, the tracker writes to a shard file (e.g. `deprecation_warning.shitlist.node-0.json`) instead of the canonical file.
+The `node_index` option is only used in save mode. When set, the tracker writes to a shard file (e.g. `deprecation_warning.shitlist.node-0.json`) instead of the canonical file. In compare mode, `node_index` is not needed because the tracker automatically checks only the buckets that the current process ran.
 
 #### Merging shards
 
@@ -200,9 +200,9 @@ DEPRECATION_TRACKER=save CI_NODE_INDEX=$NODE bundle exec rspec <subset>
 # 2. Merge phase — fan-in step, runs once after all nodes finish
 deprecations merge --delete-shards
 
-# 3. Compare phase — each parallel node checks its buckets
-#    against the merged canonical file
-DEPRECATION_TRACKER=compare CI_NODE_INDEX=$NODE bundle exec rspec <subset>
+# 3. Compare phase — each parallel node checks only its own buckets
+#    against the merged canonical file (no CI_NODE_INDEX needed)
+DEPRECATION_TRACKER=compare bundle exec rspec <subset>
 ```
 
 ### `deprecations` command

--- a/lib/deprecation_tracker.rb
+++ b/lib/deprecation_tracker.rb
@@ -141,7 +141,7 @@ class DeprecationTracker
     @transform_message = transform_message || -> (message) { message }
     @deprecation_messages = {}
     @mode = mode ? mode.to_sym : :save
-    @node_index = @mode == :compare ? nil : node_index
+    @node_index = (@mode == :compare) ? nil : node_index
   end
 
   def parallel?

--- a/lib/deprecation_tracker.rb
+++ b/lib/deprecation_tracker.rb
@@ -141,7 +141,7 @@ class DeprecationTracker
     @transform_message = transform_message || -> (message) { message }
     @deprecation_messages = {}
     @mode = mode ? mode.to_sym : :save
-    @node_index = node_index
+    @node_index = @mode == :compare ? nil : node_index
   end
 
   def parallel?

--- a/lib/deprecation_tracker.rb
+++ b/lib/deprecation_tracker.rb
@@ -180,12 +180,10 @@ class DeprecationTracker
     stored = read_json(shitlist_path)
 
     changed_buckets = []
-    buckets_to_check = if parallel?
-      # In parallel mode, only check buckets that this node actually ran
-      normalized_deprecation_messages.select { |bucket, _| deprecation_messages.key?(bucket) }
-    else
-      normalized_deprecation_messages
-    end
+    # Only check buckets that this process actually ran.
+    # In single-process mode this is all buckets (no-op filter).
+    # In parallel mode this skips buckets belonging to other processes.
+    buckets_to_check = normalized_deprecation_messages.select { |bucket, _| deprecation_messages.key?(bucket) }
 
     buckets_to_check.each do |bucket, messages|
       if stored[bucket] != messages

--- a/lib/deprecation_tracker.rb
+++ b/lib/deprecation_tracker.rb
@@ -141,7 +141,10 @@ class DeprecationTracker
     @transform_message = transform_message || -> (message) { message }
     @deprecation_messages = {}
     @mode = mode ? mode.to_sym : :save
-    @node_index = (@mode == :compare) ? nil : node_index
+    if @mode == :compare && node_index
+      raise ArgumentError, "node_index cannot be used with compare mode"
+    end
+    @node_index = node_index
   end
 
   def parallel?

--- a/lib/deprecation_tracker.rb
+++ b/lib/deprecation_tracker.rb
@@ -180,12 +180,8 @@ class DeprecationTracker
     stored = read_json(shitlist_path)
 
     changed_buckets = []
-    # Only check buckets that this process actually ran.
-    # In single-process mode this is all buckets (no-op filter).
-    # In parallel mode this skips buckets belonging to other processes.
-    buckets_to_check = normalized_deprecation_messages.select { |bucket, _| deprecation_messages.key?(bucket) }
 
-    buckets_to_check.each do |bucket, messages|
+    normalized_deprecation_messages.each do |bucket, messages|
       if stored[bucket] != messages
         changed_buckets << bucket
       end

--- a/spec/deprecation_tracker_spec.rb
+++ b/spec/deprecation_tracker_spec.rb
@@ -378,20 +378,10 @@ RSpec.describe DeprecationTracker do
         expect { tracker.compare }.not_to raise_error
       end
 
-      it "ignores node_index and only checks buckets this process ran" do
-        setup_tracker = DeprecationTracker.new(shitlist_path)
-        setup_tracker.bucket = "bucket 1"
-        setup_tracker.add("a")
-        setup_tracker.bucket = "bucket 2"
-        setup_tracker.add("b")
-        setup_tracker.save
-
-        # node_index passed (real-world config uses same block for save and compare)
-        tracker = DeprecationTracker.new(shitlist_path, nil, :compare, node_index: "0")
-        tracker.bucket = "bucket 2"
-        tracker.add("b")
-
-        expect { tracker.compare }.not_to raise_error
+      it "raises error when node_index is passed with compare mode" do
+        expect do
+          DeprecationTracker.new(shitlist_path, nil, :compare, node_index: "0")
+        end.to raise_error(ArgumentError, "node_index cannot be used with compare mode")
       end
 
       it "raises when this process's buckets have changed" do

--- a/spec/deprecation_tracker_spec.rb
+++ b/spec/deprecation_tracker_spec.rb
@@ -361,7 +361,7 @@ RSpec.describe DeprecationTracker do
     end
 
     describe "#compare" do
-      it "only checks buckets that this node ran" do
+      it "only checks buckets that this process ran (without node_index)" do
         # Set up canonical shitlist with two buckets
         setup_tracker = DeprecationTracker.new(shitlist_path)
         setup_tracker.bucket = "bucket 1"
@@ -370,7 +370,23 @@ RSpec.describe DeprecationTracker do
         setup_tracker.add("b")
         setup_tracker.save
 
-        # Parallel node only runs bucket 2 with matching deprecations
+        # Process only runs bucket 2 with matching deprecations, no node_index needed
+        tracker = DeprecationTracker.new(shitlist_path, nil, :compare)
+        tracker.bucket = "bucket 2"
+        tracker.add("b")
+
+        expect { tracker.compare }.not_to raise_error
+      end
+
+      it "ignores node_index and only checks buckets this process ran" do
+        setup_tracker = DeprecationTracker.new(shitlist_path)
+        setup_tracker.bucket = "bucket 1"
+        setup_tracker.add("a")
+        setup_tracker.bucket = "bucket 2"
+        setup_tracker.add("b")
+        setup_tracker.save
+
+        # node_index passed (real-world config uses same block for save and compare)
         tracker = DeprecationTracker.new(shitlist_path, nil, :compare, node_index: "0")
         tracker.bucket = "bucket 2"
         tracker.add("b")
@@ -378,13 +394,13 @@ RSpec.describe DeprecationTracker do
         expect { tracker.compare }.not_to raise_error
       end
 
-      it "raises when this node's buckets have changed" do
+      it "raises when this process's buckets have changed" do
         setup_tracker = DeprecationTracker.new(shitlist_path)
         setup_tracker.bucket = "bucket 1"
         setup_tracker.add("a")
         setup_tracker.save
 
-        tracker = DeprecationTracker.new(shitlist_path, nil, :compare, node_index: "0")
+        tracker = DeprecationTracker.new(shitlist_path, nil, :compare)
         tracker.bucket = "bucket 1"
         tracker.add("different")
 


### PR DESCRIPTION
## Summary

Compare mode should only run on the final merged shitlist, not on individual shard files. As Ariel noted, shard-level compare is misleading because adding/removing tests changes file distribution across shards.

This PR enforces that pattern by:
- Preventing use of `node_index` with compare mode (raises error)
- Ensures `node_index` is only for save mode (writing shard files)
- Updated README to clarify `node_index` is save-mode only
- Updated test to verify compare + node_index rejects with clear error

This forces correct usage: compare only runs after merge command on final results.