### PR TITLE
docs: Add Docker wiki reference to CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -34,6 +34,10 @@ To run all of the tests, simply run:
 bundle exec rake
 ```
 
+### Testing against specific Ruby versions
+
+See the [Docker Development Environment for Old Ruby Versions](https://github.com/fastruby/next_rails/wiki/Docker-Development-Environment-for-Old-Ruby-Versions) wiki page for setup and examples.
+
 ## A word on the changelog
 
 You may also notice that we have a changelog in the form of [CHANGELOG.md](CHANGELOG.md). We use a format based on [Keep A Changelog](https://keepachangelog.com/en/1.0.0/).


### PR DESCRIPTION
Add link to the Docker Development Environment wiki page for testing against legacy Ruby versions.

The wiki page provides setup instructions and examples for testing on Ruby 2.3, 2.4, and 2.5 using Docker, without needing to install those versions locally.

Useful for debugging version-specific syntax issues like Ruby 2.3 block parameter parsing.

https://github.com/fastruby/next_rails/wiki/Docker-Development-Environment-for-Old-Ruby-Versions