### PR TITLE
Replace rainbow gem with native NextRails::Tint wrapper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,8 @@
 # main [(unreleased)](https://github.com/fastruby/next_rails/compare/v1.5.0...main)
 
-- [BUGFIX: example](https://github.com/fastruby/next_rails/pull/<number>)
+- [BUGFIX: example](https://github.com/fastruby/next_rails/pull/183)
 
-- [CHORE: Drop `rainbow` gem dependency in favor of a native `NextRails::Tint` ANSI wrapper](https://github.com/fastruby/next_rails/pull/<number>)
+- [CHORE: Drop `rainbow` gem dependency in favor of a native `NextRails::Tint` ANSI wrapper](https://github.com/fastruby/next_rails/pull/183)
 - [BUGFIX: Compare mode now checks only buckets the current process ran, fixing parallel test support](https://github.com/fastruby/next_rails/pull/179)
 - [FEATURE: Add `deprecations merge` command to combine parallel CI shards](https://github.com/fastruby/next_rails/pull/177)
 - [FEATURE: Add parallel CI support for DeprecationTracker](https://github.com/fastruby/next_rails/pull/176)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # main [(unreleased)](https://github.com/fastruby/next_rails/compare/v1.5.0...main)
 
-- [BUGFIX: example](https://github.com/fastruby/next_rails/pull/183)
+- [BUGFIX: example](https://github.com/fastruby/next_rails/pull/<number>)
 
 - [CHORE: Drop `rainbow` gem dependency in favor of a native `NextRails::Tint` ANSI wrapper](https://github.com/fastruby/next_rails/pull/183)
 - [BUGFIX: Compare mode now checks only buckets the current process ran, fixing parallel test support](https://github.com/fastruby/next_rails/pull/179)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - [BUGFIX: example](https://github.com/fastruby/next_rails/pull/<number>)
 
+- [CHORE: Drop `rainbow` gem dependency in favor of a native `NextRails::Tint` ANSI wrapper](https://github.com/fastruby/next_rails/pull/<number>)
 - [BUGFIX: Compare mode now checks only buckets the current process ran, fixing parallel test support](https://github.com/fastruby/next_rails/pull/179)
 - [FEATURE: Add `deprecations merge` command to combine parallel CI shards](https://github.com/fastruby/next_rails/pull/177)
 - [FEATURE: Add parallel CI support for DeprecationTracker](https://github.com/fastruby/next_rails/pull/176)

--- a/lib/deprecation_tracker.rb
+++ b/lib/deprecation_tracker.rb
@@ -209,7 +209,7 @@ class DeprecationTracker
         See \e[4;37mdev-docs/testing/deprecation_tracker.md\e[0;31m for more information.
       MESSAGE
 
-      raise UnexpectedDeprecations, NextRails::Tint[message].red
+      raise UnexpectedDeprecations, NextRails::Tint(message).red
     end
   end
 

--- a/lib/deprecation_tracker.rb
+++ b/lib/deprecation_tracker.rb
@@ -1,4 +1,4 @@
-require "rainbow"
+require "next_rails/tint"
 require "json"
 
 # A shitlist for deprecation warnings during test runs. It has two modes: "save" and "compare"
@@ -209,7 +209,7 @@ class DeprecationTracker
         See \e[4;37mdev-docs/testing/deprecation_tracker.md\e[0;31m for more information.
       MESSAGE
 
-      raise UnexpectedDeprecations, Rainbow(message).red
+      raise UnexpectedDeprecations, NextRails::Tint[message].red
     end
   end
 

--- a/lib/next_rails/bundle_report.rb
+++ b/lib/next_rails/bundle_report.rb
@@ -105,14 +105,14 @@ module NextRails
         header = "#{gem.name} #{gem.version}"
 
         puts <<-MESSAGE
-          #{NextRails::Tint[header].bold.white}: released #{gem.age} (latest version, #{gem.latest_version.version}, released #{gem.latest_version.age})
+          #{NextRails::Tint(header).bold.white}: released #{gem.age} (latest version, #{gem.latest_version.version}, released #{gem.latest_version.age})
         MESSAGE
       end
 
       percentage_out_of_date = ((out_of_date_gems.count / total_gem_count.to_f) * 100).round
       footer = <<-MESSAGE
-        #{NextRails::Tint[sourced_from_git_count.to_s].yellow} gems are sourced from git
-        #{NextRails::Tint[out_of_date_gems.count.to_s].red} of the #{total_gem_count} gems are out-of-date (#{percentage_out_of_date}%)
+        #{NextRails::Tint(sourced_from_git_count.to_s).yellow} gems are sourced from git
+        #{NextRails::Tint(out_of_date_gems.count.to_s).red} of the #{total_gem_count} gems are out-of-date (#{percentage_out_of_date}%)
       MESSAGE
 
       puts ''

--- a/lib/next_rails/bundle_report.rb
+++ b/lib/next_rails/bundle_report.rb
@@ -1,4 +1,4 @@
-require "rainbow"
+require "next_rails/tint"
 require "cgi"
 require "erb"
 require "json"
@@ -105,14 +105,14 @@ module NextRails
         header = "#{gem.name} #{gem.version}"
 
         puts <<-MESSAGE
-          #{Rainbow(header).bold.white}: released #{gem.age} (latest version, #{gem.latest_version.version}, released #{gem.latest_version.age})
+          #{NextRails::Tint[header].bold.white}: released #{gem.age} (latest version, #{gem.latest_version.version}, released #{gem.latest_version.age})
         MESSAGE
       end
 
       percentage_out_of_date = ((out_of_date_gems.count / total_gem_count.to_f) * 100).round
       footer = <<-MESSAGE
-        #{Rainbow(sourced_from_git_count.to_s).yellow} gems are sourced from git
-        #{Rainbow(out_of_date_gems.count.to_s).red} of the #{total_gem_count} gems are out-of-date (#{percentage_out_of_date}%)
+        #{NextRails::Tint[sourced_from_git_count.to_s].yellow} gems are sourced from git
+        #{NextRails::Tint[out_of_date_gems.count.to_s].red} of the #{total_gem_count} gems are out-of-date (#{percentage_out_of_date}%)
       MESSAGE
 
       puts ''

--- a/lib/next_rails/bundle_report/cli.rb
+++ b/lib/next_rails/bundle_report/cli.rb
@@ -3,6 +3,7 @@
 require "optparse"
 require "next_rails"
 require "next_rails/bundle_report"
+require "next_rails/tint"
 
 class NextRails::BundleReport::CLI
   def initialize(argv)
@@ -89,7 +90,7 @@ class NextRails::BundleReport::CLI
     begin
       option_parser.parse!(@argv)
     rescue OptionParser::ParseError => e
-      warn NextRails::Tint[e.message].red
+      warn NextRails::Tint(e.message).red
       puts option_parser
       exit 1
     end

--- a/lib/next_rails/bundle_report/cli.rb
+++ b/lib/next_rails/bundle_report/cli.rb
@@ -89,7 +89,7 @@ class NextRails::BundleReport::CLI
     begin
       option_parser.parse!(@argv)
     rescue OptionParser::ParseError => e
-      warn Rainbow(e.message).red
+      warn NextRails::Tint[e.message].red
       puts option_parser
       exit 1
     end

--- a/lib/next_rails/bundle_report/rails_version_compatibility.rb
+++ b/lib/next_rails/bundle_report/rails_version_compatibility.rb
@@ -1,3 +1,5 @@
+require "next_rails/tint"
+
 class NextRails::BundleReport::RailsVersionCompatibility
   def initialize(gems: NextRails::GemInfo.all, options: {})
     @gems = gems
@@ -20,8 +22,8 @@ class NextRails::BundleReport::RailsVersionCompatibility
   def erb_output
     template = <<-ERB
 <% if incompatible_gems_by_state[:found_compatible] -%>
-<%= NextRails::Tint["=> Incompatible with Rails #{rails_version} (with new versions that are compatible):"].white.bold %>
-<%= NextRails::Tint["These gems will need to be upgraded before upgrading to Rails #{rails_version}."].italic %>
+<%= NextRails::Tint("=> Incompatible with Rails #{rails_version} (with new versions that are compatible):").white.bold %>
+<%= NextRails::Tint("These gems will need to be upgraded before upgrading to Rails #{rails_version}.").italic %>
 
 <% incompatible_gems_by_state[:found_compatible].each do |gem| -%>
 <%= gem_header(gem) %> - upgrade to <%= gem.latest_compatible_version.version %>
@@ -29,8 +31,8 @@ class NextRails::BundleReport::RailsVersionCompatibility
 
 <% end -%>
 <% if incompatible_gems_by_state[:incompatible] -%>
-<%= NextRails::Tint["=> Incompatible with Rails #{rails_version} (with no new compatible versions):"].white.bold %>
-<%= NextRails::Tint["These gems will need to be removed or replaced before upgrading to Rails #{rails_version}."].italic %>
+<%= NextRails::Tint("=> Incompatible with Rails #{rails_version} (with no new compatible versions):").white.bold %>
+<%= NextRails::Tint("These gems will need to be removed or replaced before upgrading to Rails #{rails_version}.").italic %>
 
 <% incompatible_gems_by_state[:incompatible].each do |gem| -%>
 <%= gem_header(gem) %> - new version, <%= gem.latest_version.version %>, is not compatible with Rails #{rails_version}
@@ -38,16 +40,16 @@ class NextRails::BundleReport::RailsVersionCompatibility
 
 <% end -%>
 <% if incompatible_gems_by_state[:no_new_version] -%>
-<%= NextRails::Tint["=> Incompatible with Rails #{rails_version} (with no new versions):"].white.bold %>
-<%= NextRails::Tint["These gems will need to be upgraded by us or removed before upgrading to Rails #{rails_version}."].italic %>
-<%= NextRails::Tint["This list is likely to contain internal gems, like Cuddlefish."].italic %>
+<%= NextRails::Tint("=> Incompatible with Rails #{rails_version} (with no new versions):").white.bold %>
+<%= NextRails::Tint("These gems will need to be upgraded by us or removed before upgrading to Rails #{rails_version}.").italic %>
+<%= NextRails::Tint("This list is likely to contain internal gems, like Cuddlefish.").italic %>
 
 <% incompatible_gems_by_state[:no_new_version].each do |gem| -%>
 <%= gem_header(gem) %> - new version not found
 <% end -%>
 
 <% end -%>
-<%= NextRails::Tint[incompatible_gems.length.to_s].red %> gems incompatible with Rails <%= rails_version %>
+<%= NextRails::Tint(incompatible_gems.length.to_s).red %> gems incompatible with Rails <%= rails_version %>
     ERB
 
     erb_version = ERB.version
@@ -63,8 +65,8 @@ class NextRails::BundleReport::RailsVersionCompatibility
   end
 
   def gem_header(_gem)
-    parts = [NextRails::Tint["#{_gem.name} #{_gem.version}"].bold]
-    parts << NextRails::Tint[" (loaded from git)"].magenta if _gem.sourced_from_git?
+    parts = [NextRails::Tint("#{_gem.name} #{_gem.version}").bold]
+    parts << NextRails::Tint(" (loaded from git)").magenta if _gem.sourced_from_git?
     parts.join
   end
 

--- a/lib/next_rails/bundle_report/rails_version_compatibility.rb
+++ b/lib/next_rails/bundle_report/rails_version_compatibility.rb
@@ -20,8 +20,8 @@ class NextRails::BundleReport::RailsVersionCompatibility
   def erb_output
     template = <<-ERB
 <% if incompatible_gems_by_state[:found_compatible] -%>
-<%= Rainbow("=> Incompatible with Rails #{rails_version} (with new versions that are compatible):").white.bold %>
-<%= Rainbow("These gems will need to be upgraded before upgrading to Rails #{rails_version}.").italic %>
+<%= NextRails::Tint["=> Incompatible with Rails #{rails_version} (with new versions that are compatible):"].white.bold %>
+<%= NextRails::Tint["These gems will need to be upgraded before upgrading to Rails #{rails_version}."].italic %>
 
 <% incompatible_gems_by_state[:found_compatible].each do |gem| -%>
 <%= gem_header(gem) %> - upgrade to <%= gem.latest_compatible_version.version %>
@@ -29,8 +29,8 @@ class NextRails::BundleReport::RailsVersionCompatibility
 
 <% end -%>
 <% if incompatible_gems_by_state[:incompatible] -%>
-<%= Rainbow("=> Incompatible with Rails #{rails_version} (with no new compatible versions):").white.bold %>
-<%= Rainbow("These gems will need to be removed or replaced before upgrading to Rails #{rails_version}.").italic %>
+<%= NextRails::Tint["=> Incompatible with Rails #{rails_version} (with no new compatible versions):"].white.bold %>
+<%= NextRails::Tint["These gems will need to be removed or replaced before upgrading to Rails #{rails_version}."].italic %>
 
 <% incompatible_gems_by_state[:incompatible].each do |gem| -%>
 <%= gem_header(gem) %> - new version, <%= gem.latest_version.version %>, is not compatible with Rails #{rails_version}
@@ -38,16 +38,16 @@ class NextRails::BundleReport::RailsVersionCompatibility
 
 <% end -%>
 <% if incompatible_gems_by_state[:no_new_version] -%>
-<%= Rainbow("=> Incompatible with Rails #{rails_version} (with no new versions):").white.bold %>
-<%= Rainbow("These gems will need to be upgraded by us or removed before upgrading to Rails #{rails_version}.").italic %>
-<%= Rainbow("This list is likely to contain internal gems, like Cuddlefish.").italic %>
+<%= NextRails::Tint["=> Incompatible with Rails #{rails_version} (with no new versions):"].white.bold %>
+<%= NextRails::Tint["These gems will need to be upgraded by us or removed before upgrading to Rails #{rails_version}."].italic %>
+<%= NextRails::Tint["This list is likely to contain internal gems, like Cuddlefish."].italic %>
 
 <% incompatible_gems_by_state[:no_new_version].each do |gem| -%>
 <%= gem_header(gem) %> - new version not found
 <% end -%>
 
 <% end -%>
-<%= Rainbow(incompatible_gems.length.to_s).red %> gems incompatible with Rails <%= rails_version %>
+<%= NextRails::Tint[incompatible_gems.length.to_s].red %> gems incompatible with Rails <%= rails_version %>
     ERB
 
     erb_version = ERB.version
@@ -63,9 +63,9 @@ class NextRails::BundleReport::RailsVersionCompatibility
   end
 
   def gem_header(_gem)
-    header = Rainbow("#{_gem.name} #{_gem.version}").bold
-    header << Rainbow(" (loaded from git)").magenta if _gem.sourced_from_git?
-    header
+    parts = [NextRails::Tint["#{_gem.name} #{_gem.version}"].bold]
+    parts << NextRails::Tint[" (loaded from git)"].magenta if _gem.sourced_from_git?
+    parts.join
   end
 
   def incompatible_gems

--- a/lib/next_rails/bundle_report/ruby_version_compatibility.rb
+++ b/lib/next_rails/bundle_report/ruby_version_compatibility.rb
@@ -1,4 +1,4 @@
-require "rainbow"
+require "next_rails/tint"
 
 class NextRails::BundleReport::RubyVersionCompatibility
   MINIMAL_VERSION = 1.0
@@ -18,12 +18,17 @@ class NextRails::BundleReport::RubyVersionCompatibility
   private
 
   def message
-    output = Rainbow("=> Incompatible gems with Ruby #{ruby_version}:").white.bold
-    incompatible.each do |gem|
-      output += Rainbow("\n#{gem.name} - required Ruby version: #{gem.gem_specification.required_ruby_version}").magenta
-    end
-    output += Rainbow("\n\n#{incompatible.length} incompatible #{incompatible.one? ? 'gem' : 'gems' } with Ruby #{ruby_version}").red
-    output
+    gem_lines = incompatible.map { |gem|
+      NextRails::Tint["#{gem.name} - required Ruby version: #{gem.gem_specification.required_ruby_version}"].magenta
+    }.join("\n")
+    noun = incompatible.one? ? "gem" : "gems"
+
+    <<~MESSAGE
+      #{NextRails::Tint["=> Incompatible gems with Ruby #{ruby_version}:"].white.bold}
+      #{gem_lines}
+
+      #{NextRails::Tint["#{incompatible.length} incompatible #{noun} with Ruby #{ruby_version}"].red}
+    MESSAGE
   end
 
   def incompatible
@@ -35,7 +40,7 @@ class NextRails::BundleReport::RubyVersionCompatibility
   end
 
   def invalid_message
-    Rainbow("=> Invalid Ruby version: #{options[:ruby_version]}.").red.bold
+    NextRails::Tint["=> Invalid Ruby version: #{options[:ruby_version]}."].red.bold
   end
 
   def valid?

--- a/lib/next_rails/bundle_report/ruby_version_compatibility.rb
+++ b/lib/next_rails/bundle_report/ruby_version_compatibility.rb
@@ -16,17 +16,14 @@ class NextRails::BundleReport::RubyVersionCompatibility
   private
 
   def message
-    gem_lines = incompatible.map { |gem|
-      NextRails::Tint["#{gem.name} - required Ruby version: #{gem.gem_specification.required_ruby_version}"].magenta
-    }.join("\n")
     noun = incompatible.one? ? "gem" : "gems"
-
-    <<~MESSAGE
-      #{NextRails::Tint["=> Incompatible gems with Ruby #{ruby_version}:"].white.bold}
-      #{gem_lines}
-
-      #{NextRails::Tint["#{incompatible.length} incompatible #{noun} with Ruby #{ruby_version}"].red}
-    MESSAGE
+    parts = [NextRails::Tint("=> Incompatible gems with Ruby #{ruby_version}:").white.bold]
+    incompatible.each do |gem|
+      parts << NextRails::Tint("#{gem.name} - required Ruby version: #{gem.gem_specification.required_ruby_version}").magenta
+    end
+    parts << ""
+    parts << NextRails::Tint("#{incompatible.length} incompatible #{noun} with Ruby #{ruby_version}").red
+    parts.join("\n")
   end
 
   def incompatible
@@ -38,7 +35,7 @@ class NextRails::BundleReport::RubyVersionCompatibility
   end
 
   def invalid_message
-    NextRails::Tint["=> Invalid Ruby version: #{options[:ruby_version]}."].red.bold
+    NextRails::Tint("=> Invalid Ruby version: #{options[:ruby_version]}.").red.bold
   end
 
   def valid?

--- a/lib/next_rails/bundle_report/ruby_version_compatibility.rb
+++ b/lib/next_rails/bundle_report/ruby_version_compatibility.rb
@@ -10,9 +10,7 @@ class NextRails::BundleReport::RubyVersionCompatibility
   end
 
   def generate
-    return invalid_message unless valid?
-
-    message
+    (valid? ? message : invalid_message).to_s
   end
 
   private
@@ -40,7 +38,7 @@ class NextRails::BundleReport::RubyVersionCompatibility
   end
 
   def invalid_message
-    NextRails::Tint["=> Invalid Ruby version: #{options[:ruby_version]}."].red.bold.to_s
+    NextRails::Tint["=> Invalid Ruby version: #{options[:ruby_version]}."].red.bold
   end
 
   def valid?

--- a/lib/next_rails/bundle_report/ruby_version_compatibility.rb
+++ b/lib/next_rails/bundle_report/ruby_version_compatibility.rb
@@ -40,7 +40,7 @@ class NextRails::BundleReport::RubyVersionCompatibility
   end
 
   def invalid_message
-    NextRails::Tint["=> Invalid Ruby version: #{options[:ruby_version]}."].red.bold
+    NextRails::Tint["=> Invalid Ruby version: #{options[:ruby_version]}."].red.bold.to_s
   end
 
   def valid?

--- a/lib/next_rails/tint.rb
+++ b/lib/next_rails/tint.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+module NextRails
+  # Lightweight ANSI color/style wrapper with chainable style methods.
+  # Wrap a string with `NextRails::Tint["text"]` then chain styles:
+  #
+  #   NextRails::Tint["hello"].red.bold
+  class Tint
+    CODES = {
+      bold: 1,
+      italic: 3,
+      red: 31,
+      green: 32,
+      yellow: 33,
+      blue: 34,
+      magenta: 35,
+      cyan: 36,
+      white: 37
+    }.freeze
+
+    def self.[](string)
+      new(string)
+    end
+
+    def initialize(string)
+      @string = string.to_s
+      @codes = []
+    end
+
+    CODES.each_key do |style|
+      define_method(style) do
+        @codes << CODES[style]
+        self
+      end
+    end
+
+    def to_s
+      return @string if @codes.empty?
+      "\e[#{@codes.join(";")}m#{@string}\e[0m"
+    end
+    alias_method :to_str, :to_s
+  end
+end

--- a/lib/next_rails/tint.rb
+++ b/lib/next_rails/tint.rb
@@ -2,9 +2,13 @@
 
 module NextRails
   # Lightweight ANSI color/style wrapper with chainable style methods.
-  # Wrap a string with `NextRails::Tint["text"]` then chain styles:
+  # Wrap a string with `NextRails::Tint("text")` then chain styles:
   #
-  #   NextRails::Tint["hello"].red.bold
+  #   NextRails::Tint("hello").red.bold
+  #
+  # Instances are effectively immutable: each style method returns a new
+  # `Tint` rather than mutating the receiver, so a reference can be reused
+  # without styles accumulating across chains.
   class Tint
     CODES = {
       bold: 1,
@@ -18,26 +22,26 @@ module NextRails
       white: 37
     }.freeze
 
-    def self.[](string)
-      new(string)
-    end
-
-    def initialize(string)
+    def initialize(string, codes = [])
       @string = string.to_s
-      @codes = []
+      @codes = codes
     end
 
     CODES.each_key do |style|
       define_method(style) do
-        @codes << CODES[style]
-        self
+        self.class.new(@string, @codes + [CODES[style]])
       end
     end
 
     def to_s
       return @string if @codes.empty?
+
       "\e[#{@codes.join(";")}m#{@string}\e[0m"
     end
     alias_method :to_str, :to_s
+  end
+
+  def self.Tint(string)
+    Tint.new(string)
   end
 end

--- a/next_rails.gemspec
+++ b/next_rails.gemspec
@@ -22,7 +22,6 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "rainbow", ">= 3"
   spec.add_development_dependency "bundler", ">= 1.16"
   spec.add_development_dependency "rake"
   spec.add_development_dependency "rspec", "~> 3.0"

--- a/spec/deprecation_tracker_spec.rb
+++ b/spec/deprecation_tracker_spec.rb
@@ -85,6 +85,22 @@ RSpec.describe DeprecationTracker do
 
       expect { subject.compare }.to raise_error(DeprecationTracker::UnexpectedDeprecations, /Deprecation warnings have changed/)
     end
+
+    it "wraps the raised message with red ANSI escape codes" do
+      setup_tracker = DeprecationTracker.new(shitlist_path)
+      setup_tracker.bucket = "bucket 1"
+      setup_tracker.add("a")
+      setup_tracker.save
+
+      subject = DeprecationTracker.new(shitlist_path)
+      subject.bucket = "bucket 1"
+      subject.add("b")
+
+      expect { subject.compare }.to raise_error(DeprecationTracker::UnexpectedDeprecations) do |error|
+        expect(error.message).to start_with("\e[31m")
+        expect(error.message).to end_with("\e[0m")
+      end
+    end
   end
 
   describe "#save" do

--- a/spec/next_rails/bundle_report_spec.rb
+++ b/spec/next_rails/bundle_report_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require "rainbow"
+require "next_rails/tint"
 require "spec_helper"
 
 RSpec.describe NextRails::BundleReport do
@@ -30,14 +30,14 @@ RSpec.describe NextRails::BundleReport do
       it 'invokes $stdout.puts properly', :aggregate_failures do
         allow($stdout)
           .to receive(:puts)
-          .with("#{Rainbow('alpha 0.0.1').bold.white}: released #{alpha_age} (latest version, 0.0.2, released #{bravo_age})\n")
+          .with("#{NextRails::Tint['alpha 0.0.1'].bold.white}: released #{alpha_age} (latest version, 0.0.2, released #{bravo_age})\n")
         allow($stdout)
           .to receive(:puts)
-          .with("#{Rainbow('bravo 0.2.0').bold.white}: released #{bravo_age} (latest version, 0.2.2, released #{charlie_age})\n")
+          .with("#{NextRails::Tint['bravo 0.2.0'].bold.white}: released #{bravo_age} (latest version, 0.2.2, released #{charlie_age})\n")
         allow($stdout).to receive(:puts).with('')
         allow($stdout).to receive(:puts).with(<<-EO_MULTLINE_STRING)
-          #{Rainbow('1').yellow} gems are sourced from git
-          #{Rainbow('2').red} of the 2 gems are out-of-date (100%)
+          #{NextRails::Tint['1'].yellow} gems are sourced from git
+          #{NextRails::Tint['2'].red} of the 2 gems are out-of-date (100%)
         EO_MULTLINE_STRING
       end
     end

--- a/spec/next_rails/bundle_report_spec.rb
+++ b/spec/next_rails/bundle_report_spec.rb
@@ -30,14 +30,14 @@ RSpec.describe NextRails::BundleReport do
       it 'invokes $stdout.puts properly', :aggregate_failures do
         allow($stdout)
           .to receive(:puts)
-          .with("#{NextRails::Tint['alpha 0.0.1'].bold.white}: released #{alpha_age} (latest version, 0.0.2, released #{bravo_age})\n")
+          .with("#{NextRails::Tint('alpha 0.0.1').bold.white}: released #{alpha_age} (latest version, 0.0.2, released #{bravo_age})\n")
         allow($stdout)
           .to receive(:puts)
-          .with("#{NextRails::Tint['bravo 0.2.0'].bold.white}: released #{bravo_age} (latest version, 0.2.2, released #{charlie_age})\n")
+          .with("#{NextRails::Tint('bravo 0.2.0').bold.white}: released #{bravo_age} (latest version, 0.2.2, released #{charlie_age})\n")
         allow($stdout).to receive(:puts).with('')
         allow($stdout).to receive(:puts).with(<<-EO_MULTLINE_STRING)
-          #{NextRails::Tint['1'].yellow} gems are sourced from git
-          #{NextRails::Tint['2'].red} of the 2 gems are out-of-date (100%)
+          #{NextRails::Tint('1').yellow} gems are sourced from git
+          #{NextRails::Tint('2').red} of the 2 gems are out-of-date (100%)
         EO_MULTLINE_STRING
       end
     end

--- a/spec/next_rails/tint_spec.rb
+++ b/spec/next_rails/tint_spec.rb
@@ -5,23 +5,30 @@ require "spec_helper"
 
 RSpec.describe NextRails::Tint do
   it "returns the plain string when no styles are applied" do
-    expect(NextRails::Tint["hello"].to_s).to eq("hello")
+    expect(NextRails::Tint("hello").to_s).to eq("hello")
   end
 
   it "wraps the string with a single ANSI code" do
-    expect(NextRails::Tint["hello"].red.to_s).to eq("\e[31mhello\e[0m")
+    expect(NextRails::Tint("hello").red.to_s).to eq("\e[31mhello\e[0m")
   end
 
   it "chains multiple styles into one escape sequence" do
-    expect(NextRails::Tint["hello"].bold.white.to_s).to eq("\e[1;37mhello\e[0m")
+    expect(NextRails::Tint("hello").bold.white.to_s).to eq("\e[1;37mhello\e[0m")
   end
 
   it "interpolates cleanly into another string" do
-    expect("hi #{NextRails::Tint['there'].green}!").to eq("hi \e[32mthere\e[0m!")
+    expect("hi #{NextRails::Tint('there').green}!").to eq("hi \e[32mthere\e[0m!")
   end
 
   it "joins with other Tints via Array#join through to_str coercion" do
-    joined = [NextRails::Tint["a"].red, NextRails::Tint["b"].green].join
+    joined = [NextRails::Tint("a").red, NextRails::Tint("b").green].join
     expect(joined).to eq("\e[31ma\e[0m\e[32mb\e[0m")
+  end
+
+  it "does not accumulate codes across chains on a shared instance" do
+    base = NextRails::Tint("hi")
+    expect(base.red.to_s).to eq("\e[31mhi\e[0m")
+    expect(base.bold.to_s).to eq("\e[1mhi\e[0m")
+    expect(base.to_s).to eq("hi")
   end
 end

--- a/spec/next_rails/tint_spec.rb
+++ b/spec/next_rails/tint_spec.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+require "next_rails/tint"
+require "spec_helper"
+
+RSpec.describe NextRails::Tint do
+  it "returns the plain string when no styles are applied" do
+    expect(NextRails::Tint["hello"].to_s).to eq("hello")
+  end
+
+  it "wraps the string with a single ANSI code" do
+    expect(NextRails::Tint["hello"].red.to_s).to eq("\e[31mhello\e[0m")
+  end
+
+  it "chains multiple styles into one escape sequence" do
+    expect(NextRails::Tint["hello"].bold.white.to_s).to eq("\e[1;37mhello\e[0m")
+  end
+
+  it "interpolates cleanly into another string" do
+    expect("hi #{NextRails::Tint['there'].green}!").to eq("hi \e[32mthere\e[0m!")
+  end
+
+  it "joins with other Tints via Array#join through to_str coercion" do
+    joined = [NextRails::Tint["a"].red, NextRails::Tint["b"].green].join
+    expect(joined).to eq("\e[31ma\e[0m\e[32mb\e[0m")
+  end
+end


### PR DESCRIPTION
## Summary

Replaces the `rainbow` runtime dependency with a small native ANSI wrapper, `NextRails::Tint`, dropping an external gem in favor of ~30 lines of pure Ruby.

### Why drop the dependency

`next_rails` is an **upgrade toolkit** that has to run inside other people's Gemfiles across Ruby 2.3 → 4.0. Every runtime dependency we carry is one more constraint on the host application's bundle, one more compatibility surface to maintain across that long Ruby range, and one more thing that can conflict during the very upgrade we're trying to help with. The less we ask of the host environment, the less intrusive we are. Color formatting is trivial enough (a handful of ANSI escape codes) that pulling in an external gem isn't worth the cost.

- New `NextRails::Tint` class (`lib/next_rails/tint.rb`) with a chainable styling API: `NextRails::Tint("text").red.bold`. Style methods return new instances, so `Tint` is effectively immutable and chains never accumulate codes on a shared reference.
- Module-level factory `NextRails.Tint(string)` so call sites read `NextRails::Tint("hello").red.bold` (no Kernel pollution, mirrors how `Rainbow(...)` was invoked).
- All previous `Rainbow(...)` call sites updated to `NextRails::Tint(...)`
- `rainbow` removed from `next_rails.gemspec`
- Refactored `RubyVersionCompatibility#message` and `RailsVersionCompatibility#gem_header` to `Array#join`, removing the need for `Tint#+` / `Tint#<<` and keeping the wrapper's surface minimal (constructor + style chain + `to_s` / `to_str`)
- New specs in `spec/next_rails/tint_spec.rb` (covers immutability) and `spec/deprecation_tracker_spec.rb` (locks ANSI escape codes in the raised `UnexpectedDeprecations` message via Ruby's `to_str` coercion on `raise`)
- Per-file `require "next_rails/tint"` (no global require) so files stay loadable standalone
- All syntax kept compatible with Ruby 2.3 → 4.0 (`frozen_string_literal`, squiggly heredoc, `Hash#freeze`, `define_method`)

## Test plan

- [x] `bundle exec rake` passes locally on a supported Ruby
- [x] CI matrix (Ruby 2.3 → 4.0) green
- [x] Manual smoke: `bundle_report outdated` renders gem names wrapped in `\e[1;37m...\e[0m`; `bundle_report compatibility` renders the incompatible count wrapped in `\e[31m...\e[0m`
- [x] `deprecation_tracker` compare-mode error still rendered red — locked by new spec asserting the raised message starts with `\e[31m` and ends with `\e[0m`