### PR TITLE
Release v1.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,14 +1,14 @@
-# main [(unreleased)](https://github.com/fastruby/next_rails/compare/v1.5.0...main)
+# main [(unreleased)](https://github.com/fastruby/next_rails/compare/v1.6.0...main)
 
-- [BUGFIX: example](https://github.com/fastruby/next_rails/pull/<number>)
+* Your changes/patches go here.
+
+# v1.6.0 / 2026-05-07 [(commits)](https://github.com/fastruby/next_rails/compare/v1.5.0...v1.6.0)
 
 - [CHORE: Drop `rainbow` gem dependency in favor of a native `NextRails::Tint` ANSI wrapper](https://github.com/fastruby/next_rails/pull/183)
 - [BUGFIX: Compare mode now checks only buckets the current process ran, fixing parallel test support](https://github.com/fastruby/next_rails/pull/179)
 - [FEATURE: Add `deprecations merge` command to combine parallel CI shards](https://github.com/fastruby/next_rails/pull/177)
 - [FEATURE: Add parallel CI support for DeprecationTracker](https://github.com/fastruby/next_rails/pull/176)
 - [CHORE: Add Ruby 4.0 to the test matrix](https://github.com/fastruby/next_rails/pull/178)
-
-* Your changes/patches go here.
 
 # v1.5.0 / 2026-04-01 [(commits)](https://github.com/fastruby/next_rails/compare/v1.4.8...v1.5.0)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # main [(unreleased)](https://github.com/fastruby/next_rails/compare/v1.6.0...main)
 
+- [BUGFIX: example](https://github.com/fastruby/next_rails/pull/<number>)
+
 * Your changes/patches go here.
 
 # v1.6.0 / 2026-05-07 [(commits)](https://github.com/fastruby/next_rails/compare/v1.5.0...v1.6.0)

--- a/lib/next_rails/version.rb
+++ b/lib/next_rails/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module NextRails
-  VERSION = "1.5.0"
+  VERSION = "1.6.0"
 end


### PR DESCRIPTION
## Summary

- Bump version to 1.6.0
- Update CHANGELOG with v1.6.0 entries

## Changes in this release

- CHORE: Drop `rainbow` gem dependency in favor of native `NextRails::Tint` ANSI wrapper (#183)
- BUGFIX: Compare mode now checks only buckets the current process ran, fixing parallel test support (#179)
- FEATURE: Add `deprecations merge` command to combine parallel CI shards (#177)
- FEATURE: Add parallel CI support for DeprecationTracker (#176)
- CHORE: Add Ruby 4.0 to the test matrix (#178)

## Post-merge steps

1. `git tag v1.6.0`
2. `git push --tags`
3. `gem build next_rails.gemspec`
4. `gem push next_rails-1.6.0.gem`