### PR TITLE
Add VALID_MODES constant and validate tracker mode at initialization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # main [(unreleased)](https://github.com/fastruby/next_rails/compare/v1.6.0...main)
 
 - [BUGFIX: example](https://github.com/fastruby/next_rails/pull/<number>)
+- [FEATURE: Validate the DeprecationTracker mode at initialization, treating a blank mode as the default `save`](https://github.com/fastruby/next_rails/pull/186)
 
 * Your changes/patches go here.
 

--- a/exe/deprecations
+++ b/exe/deprecations
@@ -3,10 +3,13 @@ require "json"
 require "rainbow"
 require "optparse"
 require "set"
-require_relative "../lib/deprecation_tracker/shard_merger"
+require_relative "../lib/deprecation_tracker"
 
 def run_tests(deprecation_warnings, opts = {})
   tracker_mode = opts[:tracker_mode]
+  if tracker_mode && !DeprecationTracker::VALID_MODES.include?(tracker_mode.to_sym)
+    abort "Invalid --tracker-mode #{tracker_mode.inspect}. Must be one of: #{DeprecationTracker::VALID_MODES.map(&:to_s).join(", ")}."
+  end
   next_mode = opts[:next_mode]
   rspec_command = if next_mode
     "bin/next rspec"
@@ -69,7 +72,7 @@ option_parser = OptionParser.new do |opts|
     options[:next] = next_mode
   end
 
-  opts.on("--tracker-mode MODE", "Set DEPRECATION_TRACKER in test mode. Options: save or compare") do |tracker_mode|
+  opts.on("--tracker-mode MODE", "Set DEPRECATION_TRACKER in test mode. Options: #{DeprecationTracker::VALID_MODES.map(&:to_s).join(", ")}") do |tracker_mode|
     options[:tracker_mode] = tracker_mode
   end
 

--- a/exe/deprecations
+++ b/exe/deprecations
@@ -8,8 +8,8 @@ require_relative "../lib/deprecation_tracker/shard_merger"
 
 def run_tests(deprecation_warnings, opts = {})
   tracker_mode = opts[:tracker_mode]
-  if tracker_mode && !DeprecationTracker::VALID_MODES.include?(tracker_mode.to_sym)
-    abort "Invalid --tracker-mode #{tracker_mode.inspect}. Must be one of: #{DeprecationTracker::VALID_MODES_DISPLAY}."
+  unless DeprecationTracker.valid_mode?(tracker_mode)
+    abort "Invalid --tracker-mode #{tracker_mode.inspect}. Must be one of: #{DeprecationTracker.valid_modes_display}."
   end
   next_mode = opts[:next_mode]
   rspec_command = if next_mode
@@ -73,7 +73,7 @@ option_parser = OptionParser.new do |opts|
     options[:next] = next_mode
   end
 
-  opts.on("--tracker-mode MODE", "Set DEPRECATION_TRACKER in test mode. Options: #{DeprecationTracker::VALID_MODES_DISPLAY}") do |tracker_mode|
+  opts.on("--tracker-mode MODE", "Set DEPRECATION_TRACKER in test mode. Options: #{DeprecationTracker.valid_modes_display}") do |tracker_mode|
     options[:tracker_mode] = tracker_mode
   end
 

--- a/exe/deprecations
+++ b/exe/deprecations
@@ -7,8 +7,8 @@ require_relative "../lib/deprecation_tracker/valid_modes"
 require_relative "../lib/deprecation_tracker/shard_merger"
 
 def run_tests(deprecation_warnings, opts = {})
-  tracker_mode = opts[:tracker_mode]
-  unless DeprecationTracker.valid_mode?(tracker_mode)
+  tracker_mode = DeprecationTracker.sanitize_mode(opts[:tracker_mode])
+  if tracker_mode && !DeprecationTracker.valid_mode?(tracker_mode)
     abort "Invalid --tracker-mode #{tracker_mode.inspect}. Must be one of: #{DeprecationTracker.valid_modes_display}."
   end
   next_mode = opts[:next_mode]

--- a/exe/deprecations
+++ b/exe/deprecations
@@ -3,12 +3,13 @@ require "json"
 require "rainbow"
 require "optparse"
 require "set"
-require_relative "../lib/deprecation_tracker"
+require_relative "../lib/deprecation_tracker/valid_modes"
+require_relative "../lib/deprecation_tracker/shard_merger"
 
 def run_tests(deprecation_warnings, opts = {})
   tracker_mode = opts[:tracker_mode]
   if tracker_mode && !DeprecationTracker::VALID_MODES.include?(tracker_mode.to_sym)
-    abort "Invalid --tracker-mode #{tracker_mode.inspect}. Must be one of: #{DeprecationTracker::VALID_MODES.map(&:to_s).join(", ")}."
+    abort "Invalid --tracker-mode #{tracker_mode.inspect}. Must be one of: #{DeprecationTracker::VALID_MODES_DISPLAY}."
   end
   next_mode = opts[:next_mode]
   rspec_command = if next_mode
@@ -72,7 +73,7 @@ option_parser = OptionParser.new do |opts|
     options[:next] = next_mode
   end
 
-  opts.on("--tracker-mode MODE", "Set DEPRECATION_TRACKER in test mode. Options: #{DeprecationTracker::VALID_MODES.map(&:to_s).join(", ")}") do |tracker_mode|
+  opts.on("--tracker-mode MODE", "Set DEPRECATION_TRACKER in test mode. Options: #{DeprecationTracker::VALID_MODES_DISPLAY}") do |tracker_mode|
     options[:tracker_mode] = tracker_mode
   end
 

--- a/lib/deprecation_tracker.rb
+++ b/lib/deprecation_tracker.rb
@@ -12,6 +12,7 @@ require "json"
 #
 class DeprecationTracker
   UnexpectedDeprecations = Class.new(StandardError)
+  VALID_MODES = %i[save compare].freeze
 
   module KernelWarnTracker
     def self.callbacks
@@ -141,6 +142,9 @@ class DeprecationTracker
     @transform_message = transform_message || -> (message) { message }
     @deprecation_messages = {}
     @mode = mode ? mode.to_sym : :save
+    unless VALID_MODES.include?(@mode)
+      raise ArgumentError, "mode must be one of #{VALID_MODES.map(&:to_s).join(", ")}, got: #{mode.inspect}"
+    end
     if @mode == :compare && node_index
       raise ArgumentError, "node_index cannot be used with compare mode"
     end

--- a/lib/deprecation_tracker.rb
+++ b/lib/deprecation_tracker.rb
@@ -154,7 +154,7 @@ class DeprecationTracker
     @deprecation_messages = {}
     @mode = mode ? mode.to_sym : :save
     unless self.class.valid_mode?(@mode)
-      raise ArgumentError, "mode must be one of #{self.class.valid_modes_display}, got: #{mode.inspect}"
+      raise ArgumentError, "mode must be one of: #{self.class.valid_modes_display}. Got: #{mode.inspect}"
     end
     if @mode == :compare && node_index
       raise ArgumentError, "node_index cannot be used with compare mode"

--- a/lib/deprecation_tracker.rb
+++ b/lib/deprecation_tracker.rb
@@ -77,9 +77,19 @@ class DeprecationTracker
 
   DEFAULT_PATH = "spec/support/deprecation_warning.shitlist.json"
 
+  # Returns the mode as-is, or nil when it is blank. A blank DEPRECATION_TRACKER
+  # (e.g. `DEPRECATION_TRACKER= rspec`) is truthy in Ruby, so callers can use this
+  # to treat an empty value as unset and fall back to the default mode.
+  def self.sanitize_mode(mode)
+    return if mode.nil?
+
+    stripped = mode.to_s.strip
+    stripped.empty? ? nil : stripped
+  end
+
   def self.init_tracker(opts = {})
     shitlist_path = opts[:shitlist_path] || DEFAULT_PATH
-    mode = opts[:mode] || ENV["DEPRECATION_TRACKER"] || :save
+    mode = sanitize_mode(opts[:mode] || ENV["DEPRECATION_TRACKER"]) || :save
     transform_message = opts[:transform_message]
     node_index = opts[:node_index]
     deprecation_tracker = DeprecationTracker.new(shitlist_path, transform_message, mode, node_index: node_index)
@@ -143,8 +153,8 @@ class DeprecationTracker
     @transform_message = transform_message || -> (message) { message }
     @deprecation_messages = {}
     @mode = mode ? mode.to_sym : :save
-    unless VALID_MODES.include?(@mode)
-      raise ArgumentError, "mode must be one of #{VALID_MODES_DISPLAY}, got: #{mode.inspect}"
+    unless self.class.valid_mode?(@mode)
+      raise ArgumentError, "mode must be one of #{self.class.valid_modes_display}, got: #{mode.inspect}"
     end
     if @mode == :compare && node_index
       raise ArgumentError, "node_index cannot be used with compare mode"

--- a/lib/deprecation_tracker.rb
+++ b/lib/deprecation_tracker.rb
@@ -10,9 +10,10 @@ require "json"
 # Tracks deprecation warnings, grouped by spec file. After the test run, compare against shitlist of expected
 # deprecation warnings. If anything is added or removed, raise an error with a diff of the changes.
 #
+require_relative "deprecation_tracker/valid_modes"
+
 class DeprecationTracker
   UnexpectedDeprecations = Class.new(StandardError)
-  VALID_MODES = %i[save compare].freeze
 
   module KernelWarnTracker
     def self.callbacks
@@ -143,7 +144,7 @@ class DeprecationTracker
     @deprecation_messages = {}
     @mode = mode ? mode.to_sym : :save
     unless VALID_MODES.include?(@mode)
-      raise ArgumentError, "mode must be one of #{VALID_MODES.map(&:to_s).join(", ")}, got: #{mode.inspect}"
+      raise ArgumentError, "mode must be one of #{VALID_MODES_DISPLAY}, got: #{mode.inspect}"
     end
     if @mode == :compare && node_index
       raise ArgumentError, "node_index cannot be used with compare mode"

--- a/lib/deprecation_tracker/valid_modes.rb
+++ b/lib/deprecation_tracker/valid_modes.rb
@@ -1,4 +1,12 @@
 class DeprecationTracker
   VALID_MODES = %i[save compare].freeze
-  VALID_MODES_DISPLAY = VALID_MODES.map(&:to_s).join(", ").freeze
+
+  # Human-readable list of valid modes for error messages and CLI help text.
+  def self.valid_modes_display
+    @valid_modes_display ||= VALID_MODES.map(&:to_s).join(", ")
+  end
+
+  def self.valid_mode?(mode)
+    mode && VALID_MODES.include?(mode.to_sym)
+  end
 end

--- a/lib/deprecation_tracker/valid_modes.rb
+++ b/lib/deprecation_tracker/valid_modes.rb
@@ -1,0 +1,4 @@
+class DeprecationTracker
+  VALID_MODES = %i[save compare].freeze
+  VALID_MODES_DISPLAY = VALID_MODES.map(&:to_s).join(", ").freeze
+end

--- a/spec/deprecation_tracker_spec.rb
+++ b/spec/deprecation_tracker_spec.rb
@@ -263,12 +263,6 @@ RSpec.describe DeprecationTracker do
       tracker = DeprecationTracker.new(shitlist_path, nil, nil)
       expect(tracker.mode).to eq(:save)
     end
-
-    it "raises ArgumentError for invalid mode" do
-      expect {
-        DeprecationTracker.new(shitlist_path, nil, "random_stuff")
-      }.to raise_error(ArgumentError)
-    end
   end
 
   describe "#init_tracker" do
@@ -426,11 +420,22 @@ RSpec.describe DeprecationTracker do
       expect(tracker.mode).to eq(:compare)
     end
 
-    it "raises ArgumentError when ENV['DEPRECATION_TRACKER'] is invalid" do
+    it "raises ArgumentError naming the invalid ENV['DEPRECATION_TRACKER'] value" do
       stub_const("ENV", ENV.to_h.merge("DEPRECATION_TRACKER" => "bogus"))
       expect {
         DeprecationTracker.init_tracker({})
-      }.to raise_error(ArgumentError)
+      }.to raise_error(ArgumentError, /mode must be one of save, compare.*bogus/)
+    end
+
+    it "treats a blank ENV['DEPRECATION_TRACKER'] as unset and defaults to save" do
+      stub_const("ENV", ENV.to_h.merge("DEPRECATION_TRACKER" => ""))
+      tracker = DeprecationTracker.init_tracker({})
+      expect(tracker.mode).to eq(:save)
+    end
+
+    it "treats a blank opts[:mode] as unset and defaults to save" do
+      tracker = DeprecationTracker.init_tracker(mode: "")
+      expect(tracker.mode).to eq(:save)
     end
   end
 
@@ -445,6 +450,33 @@ RSpec.describe DeprecationTracker do
           DeprecationTracker.new(shitlist_path, nil, mode)
         }.not_to raise_error
       end
+    end
+
+    it "rejects an invalid mode at construction, naming the bad value" do
+      expect {
+        DeprecationTracker.new(shitlist_path, nil, "random_stuff")
+      }.to raise_error(ArgumentError, /mode must be one of save, compare.*random_stuff/)
+    end
+  end
+
+  describe ".valid_mode?" do
+    it "returns true for valid modes, as symbol or string" do
+      expect(DeprecationTracker.valid_mode?(:save)).to be_truthy
+      expect(DeprecationTracker.valid_mode?("compare")).to be_truthy
+    end
+
+    it "returns a falsey value for an unknown mode" do
+      expect(DeprecationTracker.valid_mode?("random_stuff")).to be_falsey
+    end
+
+    it "returns a falsey value for nil" do
+      expect(DeprecationTracker.valid_mode?(nil)).to be_falsey
+    end
+  end
+
+  describe ".valid_modes_display" do
+    it "renders the valid modes as a comma-separated string" do
+      expect(DeprecationTracker.valid_modes_display).to eq("save, compare")
     end
   end
 

--- a/spec/deprecation_tracker_spec.rb
+++ b/spec/deprecation_tracker_spec.rb
@@ -424,7 +424,7 @@ RSpec.describe DeprecationTracker do
       stub_const("ENV", ENV.to_h.merge("DEPRECATION_TRACKER" => "bogus"))
       expect {
         DeprecationTracker.init_tracker({})
-      }.to raise_error(ArgumentError, /mode must be one of save, compare.*bogus/)
+      }.to raise_error(ArgumentError, /mode must be one of: save, compare\..*bogus/)
     end
 
     it "treats a blank ENV['DEPRECATION_TRACKER'] as unset and defaults to save" do
@@ -440,10 +440,6 @@ RSpec.describe DeprecationTracker do
   end
 
   describe "VALID_MODES" do
-    it "contains save and compare" do
-      expect(DeprecationTracker::VALID_MODES).to include(:save, :compare)
-    end
-
     it "accepts all valid modes without error" do
       DeprecationTracker::VALID_MODES.each do |mode|
         expect {
@@ -455,7 +451,7 @@ RSpec.describe DeprecationTracker do
     it "rejects an invalid mode at construction, naming the bad value" do
       expect {
         DeprecationTracker.new(shitlist_path, nil, "random_stuff")
-      }.to raise_error(ArgumentError, /mode must be one of save, compare.*random_stuff/)
+      }.to raise_error(ArgumentError, /mode must be one of: save, compare\..*random_stuff/)
     end
   end
 

--- a/spec/deprecation_tracker_spec.rb
+++ b/spec/deprecation_tracker_spec.rb
@@ -267,7 +267,7 @@ RSpec.describe DeprecationTracker do
     it "raises ArgumentError for invalid mode" do
       expect {
         DeprecationTracker.new(shitlist_path, nil, "random_stuff")
-      }.to raise_error(ArgumentError, /mode must be one of save, compare/)
+      }.to raise_error(ArgumentError)
     end
   end
 
@@ -430,13 +430,13 @@ RSpec.describe DeprecationTracker do
       stub_const("ENV", ENV.to_h.merge("DEPRECATION_TRACKER" => "bogus"))
       expect {
         DeprecationTracker.init_tracker({})
-      }.to raise_error(ArgumentError, /mode must be one of save, compare/)
+      }.to raise_error(ArgumentError)
     end
   end
 
   describe "VALID_MODES" do
     it "contains save and compare" do
-      expect(DeprecationTracker::VALID_MODES).to contain_exactly(:save, :compare)
+      expect(DeprecationTracker::VALID_MODES).to include(:save, :compare)
     end
 
     it "accepts all valid modes without error" do

--- a/spec/deprecation_tracker_spec.rb
+++ b/spec/deprecation_tracker_spec.rb
@@ -264,11 +264,10 @@ RSpec.describe DeprecationTracker do
       expect(tracker.mode).to eq(:save)
     end
 
-    it "does not save nor compare if mode is invalid" do
-      tracker = DeprecationTracker.new(shitlist_path, nil, "random_stuff")
-      expect(tracker).not_to receive(:save)
-      expect(tracker).not_to receive(:compare)
-      tracker.after_run
+    it "raises ArgumentError for invalid mode" do
+      expect {
+        DeprecationTracker.new(shitlist_path, nil, "random_stuff")
+      }.to raise_error(ArgumentError, /mode must be one of save, compare/)
     end
   end
 
@@ -425,6 +424,27 @@ RSpec.describe DeprecationTracker do
       stub_const("ENV", ENV.to_h.merge("DEPRECATION_TRACKER" => "compare"))
       tracker = DeprecationTracker.init_tracker({})
       expect(tracker.mode).to eq(:compare)
+    end
+
+    it "raises ArgumentError when ENV['DEPRECATION_TRACKER'] is invalid" do
+      stub_const("ENV", ENV.to_h.merge("DEPRECATION_TRACKER" => "bogus"))
+      expect {
+        DeprecationTracker.init_tracker({})
+      }.to raise_error(ArgumentError, /mode must be one of save, compare/)
+    end
+  end
+
+  describe "VALID_MODES" do
+    it "contains save and compare" do
+      expect(DeprecationTracker::VALID_MODES).to contain_exactly(:save, :compare)
+    end
+
+    it "accepts all valid modes without error" do
+      DeprecationTracker::VALID_MODES.each do |mode|
+        expect {
+          DeprecationTracker.new(shitlist_path, nil, mode)
+        }.not_to raise_error
+      end
     end
   end
 


### PR DESCRIPTION
## Description

Introduces `DeprecationTracker::VALID_MODES` as a single source of truth for accepted tracker modes (`save`, `compare`). Constants live in `lib/deprecation_tracker/valid_modes.rb` so the `exe/deprecations` CLI can load them without pulling in the full library.

## Motivation and Context

Valid mode values were duplicated as inline literals across `lib/deprecation_tracker.rb` and `exe/deprecations`. Adding or removing a mode required updating every literal. With `VALID_MODES`, one change propagates to all validation, error messages, and CLI help text automatically.

Additionally, passing an invalid mode previously silently no-oped (neither `save` nor `compare` ran after the test suite). It now raises `ArgumentError` early, covering both the library and CLI entry points.

## How Has This Been Tested?

- Updated existing test that expected silent no-op on invalid mode to now expect `ArgumentError`
- Added test for invalid `ENV['DEPRECATION_TRACKER']` value via `init_tracker`
- Added `VALID_MODES` describe block: constant membership and all valid modes construct without error
- Full spec suite passes (`bundle exec rspec spec/deprecation_tracker_spec.rb`)

## Screenshots:

N/A

**I will abide by the [code of conduct](https://github.com/fastruby/next_rails/blob/main/CODE_OF_CONDUCT.md)**