### PR TITLE
Add support for SimpleCov 1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # main [(unreleased)](https://github.com/fastruby/next_rails/compare/v1.6.0...main)
 
 - [BUGFIX: example](https://github.com/fastruby/next_rails/pull/<number>)
+- [FEATURE: Add support for SimpleCov 1.0](https://github.com/fastruby/next_rails/pull/196)
 - [FEATURE: Validate the DeprecationTracker mode at initialization, treating a blank mode as the default `save`](https://github.com/fastruby/next_rails/pull/186)
 - [BUGFIX: `bundle_report outdated` no longer confuses a locally-sourced (`path:`) gem with a same-named public gem on rubygems; local gems are excluded from the out-of-date check and counted separately](https://github.com/fastruby/next_rails/pull/189)
 

--- a/next_rails.gemspec
+++ b/next_rails.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "bundler", ">= 1.16"
   spec.add_development_dependency "rake"
   spec.add_development_dependency "rspec", "~> 3.0"
-  spec.add_development_dependency "simplecov", "~> 0.17.1"
+  spec.add_development_dependency "simplecov", ">= 0.17.1"
   spec.add_development_dependency "timecop", "~> 0.9.1"
   spec.add_development_dependency "byebug"
   spec.add_development_dependency "rexml", "3.2.5" # limited on purpose, new versions don't work with old rubies


### PR DESCRIPTION
## Description
Adds support for simplecov 1.0 in development

## Motivation and Context
Simplecov recently released it's 1.0.0 version and we want to make next_rails supports it.

## How Has This Been Tested?
I simply ran all the specs and they all passed and a report was generated successfully.

**I will abide by the [code of conduct](https://github.com/fastruby/next_rails/blob/main/CODE_OF_CONDUCT.md)**
