### PR TITLE
Fix the undeclared `rainbow` require in the deprecations executable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 - [BUGFIX: example](https://github.com/fastruby/next_rails/pull/<number>)
 - [FEATURE: Validate the DeprecationTracker mode at initialization, treating a blank mode as the default `save`](https://github.com/fastruby/next_rails/pull/186)
 - [BUGFIX: `bundle_report outdated` no longer confuses a locally-sourced (`path:`) gem with a same-named public gem on rubygems; local gems are excluded from the out-of-date check and counted separately](https://github.com/fastruby/next_rails/pull/189)
+- [BUGFIX: The `deprecations` executable no longer requires the undeclared `rainbow` gem, which made it fail to load on a clean install](https://github.com/fastruby/next_rails/pull/197)
 
 * Your changes/patches go here.
 

--- a/exe/deprecations
+++ b/exe/deprecations
@@ -1,8 +1,8 @@
 #!/usr/bin/env ruby
 require "json"
-require "rainbow"
 require "optparse"
 require "set"
+require_relative "../lib/next_rails/tint"
 require_relative "../lib/deprecation_tracker/valid_modes"
 require_relative "../lib/deprecation_tracker/shard_merger"
 
@@ -33,11 +33,11 @@ def print_info(deprecation_warnings, opts = {})
     end
   end.sort_by {|message, data| data[:occurrences] }.reverse.to_h
 
-  puts Rainbow("Ten most common deprecation warnings:").underline
+  puts NextRails::Tint("Ten most common deprecation warnings:").underline
   frequency_by_message.take(10).each do |message, data|
-    puts Rainbow("Occurrences: #{data.fetch(:occurrences)}").bold
+    puts NextRails::Tint("Occurrences: #{data.fetch(:occurrences)}").bold
     puts "Test files: #{data.fetch(:test_files).to_a.join(" ")}" if verbose
-    puts Rainbow(message).red
+    puts NextRails::Tint(message).red
     puts "----------"
   end
 end
@@ -127,10 +127,10 @@ when "run", "info"
     print_info(deprecation_warnings, verbose: options[:verbose])
   end
 when nil
-  STDERR.puts Rainbow("Must pass a mode: run, info, or merge").red
+  STDERR.puts NextRails::Tint("Must pass a mode: run, info, or merge").red
   puts option_parser
   exit 1
 else
-  STDERR.puts Rainbow("Unknown mode: #{options[:mode]}").red
+  STDERR.puts NextRails::Tint("Unknown mode: #{options[:mode]}").red
   exit 1
 end

--- a/lib/next_rails/tint.rb
+++ b/lib/next_rails/tint.rb
@@ -13,6 +13,7 @@ module NextRails
     CODES = {
       bold: 1,
       italic: 3,
+      underline: 4,
       red: 31,
       green: 32,
       yellow: 33,

--- a/spec/next_rails/tint_spec.rb
+++ b/spec/next_rails/tint_spec.rb
@@ -12,6 +12,10 @@ RSpec.describe NextRails::Tint do
     expect(NextRails::Tint("hello").red.to_s).to eq("\e[31mhello\e[0m")
   end
 
+  it "supports underline (the CLI headlines use it)" do
+    expect(NextRails::Tint("hello").underline.to_s).to eq("\e[4mhello\e[0m")
+  end
+
   it "chains multiple styles into one escape sequence" do
     expect(NextRails::Tint("hello").bold.white.to_s).to eq("\e[1;37mhello\e[0m")
   end


### PR DESCRIPTION
## Problem

`exe/deprecations` requires `rainbow`, which the gemspec never declares as a runtime dependency. v1.6.0 dropped that dependency in favor of the native `NextRails::Tint` wrapper ([#183](https://github.com/fastruby/next_rails/pull/183)), but only for `lib/`; the executable kept its `require "rainbow"`.

On a clean install the shipped executable raises `LoadError` and no mode works at all. It only appears to work where `rainbow` happens to be installed for some other reason, which is why it went unnoticed.

## Fix

Switch the CLI to `NextRails::Tint`, the dependency-free ANSI wrapper already used throughout `lib/`, and add the `underline` code (4) it was missing, since the CLI headlines use it.

## Verification

```
$ ruby -e '$LOAD_PATH.reject! { |p| p.include?("rainbow") }; load "exe/deprecations"' info --help
Usage: exe/deprecations [options] [mode]
...
```

With rainbow removed from the load path the CLI now loads and runs; before this change it aborted with `LoadError`.

