### PR TITLE
Fix NoMethodError in `deprecations run`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - [FEATURE: Validate the DeprecationTracker mode at initialization, treating a blank mode as the default `save`](https://github.com/fastruby/next_rails/pull/186)
 - [BUGFIX: `bundle_report outdated` no longer confuses a locally-sourced (`path:`) gem with a same-named public gem on rubygems; local gems are excluded from the out-of-date check and counted separately](https://github.com/fastruby/next_rails/pull/189)
 - [BUGFIX: The `deprecations` executable no longer requires the undeclared `rainbow` gem, which made it fail to load on a clean install](https://github.com/fastruby/next_rails/pull/197)
+- [BUGFIX: `deprecations run` no longer raises `NoMethodError` before doing any work](https://github.com/fastruby/next_rails/pull/198)
 
 * Your changes/patches go here.
 

--- a/lib/deprecation_tracker.rb
+++ b/lib/deprecation_tracker.rb
@@ -1,4 +1,4 @@
-require "next_rails/tint"
+require_relative "next_rails/tint"
 require "json"
 
 # A shitlist for deprecation warnings during test runs. It has two modes: "save" and "compare"
@@ -76,16 +76,6 @@ class DeprecationTracker
   end
 
   DEFAULT_PATH = "spec/support/deprecation_warning.shitlist.json"
-
-  # Returns the mode as-is, or nil when it is blank. A blank DEPRECATION_TRACKER
-  # (e.g. `DEPRECATION_TRACKER= rspec`) is truthy in Ruby, so callers can use this
-  # to treat an empty value as unset and fall back to the default mode.
-  def self.sanitize_mode(mode)
-    return if mode.nil?
-
-    stripped = mode.to_s.strip
-    stripped.empty? ? nil : stripped
-  end
 
   def self.init_tracker(opts = {})
     shitlist_path = opts[:shitlist_path] || DEFAULT_PATH

--- a/lib/deprecation_tracker/valid_modes.rb
+++ b/lib/deprecation_tracker/valid_modes.rb
@@ -9,4 +9,14 @@ class DeprecationTracker
   def self.valid_mode?(mode)
     mode && VALID_MODES.include?(mode.to_sym)
   end
+
+  # Returns the mode as-is, or nil when it is blank. A blank DEPRECATION_TRACKER
+  # (e.g. `DEPRECATION_TRACKER= rspec`) is truthy in Ruby, so callers can use this
+  # to treat an empty value as unset and fall back to the default mode.
+  def self.sanitize_mode(mode)
+    return if mode.nil?
+
+    stripped = mode.to_s.strip
+    stripped.empty? ? nil : stripped
+  end
 end

--- a/spec/deprecations_cli_spec.rb
+++ b/spec/deprecations_cli_spec.rb
@@ -1,0 +1,160 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "json"
+require "open3"
+require "tmpdir"
+require "fileutils"
+require "rbconfig"
+
+# Smoke tests that actually execute exe/deprecations. Everything here runs the real
+# script in a subprocess, so it catches the class of breakage unit tests on lib/
+# cannot: a missing require, or a mode that raises before doing any work. Two shipped
+# bugs (an undeclared `rainbow` require and a NoMethodError in `run`) survived
+# precisely because nothing ever loaded this executable.
+RSpec.describe "exe/deprecations" do
+  def cli_path
+    File.expand_path("../exe/deprecations", __dir__)
+  end
+
+  def shitlist_path
+    "spec/support/deprecation_warning.shitlist.json"
+  end
+
+  # Runs the CLI in `chdir` and returns [stdout, stderr, exitstatus].
+  def run_cli(args, chdir:)
+    stdout, stderr, status = Open3.capture3(RbConfig.ruby, cli_path, *args, chdir: chdir)
+    [stdout, stderr, status.exitstatus]
+  end
+
+  around do |example|
+    Dir.mktmpdir("deprecations-cli") do |dir|
+      @dir = dir
+      FileUtils.mkdir_p(File.join(dir, "spec", "support"))
+      example.run
+    end
+  end
+
+  attr_reader :dir
+
+  def write_shitlist(relative, contents)
+    path = File.join(dir, relative)
+    FileUtils.mkdir_p(File.dirname(path))
+    File.write(path, JSON.pretty_generate(contents))
+    path
+  end
+
+  let(:shitlist) do
+    write_shitlist(
+      shitlist_path,
+      "./spec/models/user_spec.rb" => ["DEPRECATION WARNING: default_timezone"],
+      "./spec/models/post_spec.rb" => ["DEPRECATION WARNING: partial rendering"]
+    )
+  end
+
+  describe "info" do
+    it "summarizes the shitlist" do
+      shitlist
+      stdout, _stderr, status = run_cli(["info"], chdir: dir)
+
+      expect(status).to eq(0)
+      expect(stdout).to include("Ten most common deprecation warnings:")
+      expect(stdout).to include("default_timezone")
+      expect(stdout).to include("partial rendering")
+    end
+
+    it "narrows the output with --pattern" do
+      shitlist
+      stdout, _stderr, status = run_cli(["info", "--pattern", "default_timezone"], chdir: dir)
+
+      expect(status).to eq(0)
+      expect(stdout).to include("default_timezone")
+      expect(stdout).not_to include("partial rendering")
+    end
+
+    it "lists the test files with --verbose" do
+      shitlist
+      stdout, _stderr, = run_cli(["info", "--verbose"], chdir: dir)
+
+      expect(stdout).to include("Test files: ")
+      expect(stdout).to include("user_spec.rb")
+    end
+
+    it "exits non-zero when no message matches --pattern" do
+      shitlist
+      _stdout, stderr, status = run_cli(["info", "--pattern", "nothing-matches-this"], chdir: dir)
+
+      expect(status).to eq(1)
+      expect(stderr).to include("No test files with deprecations")
+    end
+  end
+
+  describe "run" do
+    # Regression: run called DeprecationTracker.sanitize_mode while the CLI only
+    # required valid_modes, so every invocation died with NoMethodError before doing
+    # any work. Reaching the mode validation at all proves the tracker is loaded.
+    it "validates --tracker-mode instead of raising NoMethodError" do
+      shitlist
+      _stdout, stderr, status = run_cli(["run", "--tracker-mode", "bogus"], chdir: dir)
+
+      expect(status).to eq(1)
+      expect(stderr).to include("Invalid --tracker-mode")
+      expect(stderr).not_to include("NoMethodError")
+    end
+  end
+
+  describe "merge" do
+    it "writes the merged shard files to the canonical shitlist" do
+      write_shitlist(
+        "spec/support/deprecation_warning.shitlist.node-1.json",
+        "./spec/models/user_spec.rb" => ["DEPRECATION WARNING: from shard 1"]
+      )
+      write_shitlist(
+        "spec/support/deprecation_warning.shitlist.node-2.json",
+        "./spec/models/post_spec.rb" => ["DEPRECATION WARNING: from shard 2"]
+      )
+
+      stdout, _stderr, status = run_cli(["merge"], chdir: dir)
+
+      expect(status).to eq(0)
+      expect(stdout).to include("Merged 2 shard files")
+      merged = JSON.parse(File.read(File.join(dir, shitlist_path)))
+      expect(merged.fetch("./spec/models/user_spec.rb")).to eq(["DEPRECATION WARNING: from shard 1"])
+      expect(merged.fetch("./spec/models/post_spec.rb")).to eq(["DEPRECATION WARNING: from shard 2"])
+    end
+
+    # Documents current behavior: merge builds the result from the shard files alone
+    # and overwrites the canonical shitlist. Entries only present in the canonical
+    # file are dropped, not merged.
+    it "overwrites entries already in the canonical shitlist" do
+      shitlist
+      write_shitlist(
+        "spec/support/deprecation_warning.shitlist.node-1.json",
+        "./spec/models/user_spec.rb" => ["DEPRECATION WARNING: from shard 1"]
+      )
+
+      _stdout, _stderr, status = run_cli(["merge"], chdir: dir)
+
+      expect(status).to eq(0)
+      merged = JSON.parse(File.read(File.join(dir, shitlist_path)))
+      expect(merged.fetch("./spec/models/user_spec.rb")).to eq(["DEPRECATION WARNING: from shard 1"])
+      expect(merged).not_to have_key("./spec/models/post_spec.rb")
+    end
+  end
+
+  describe "mode handling" do
+    it "exits non-zero with usage when no mode is given" do
+      _stdout, stderr, status = run_cli([], chdir: dir)
+
+      expect(status).to eq(1)
+      expect(stderr).to include("Must pass a mode")
+    end
+
+    it "exits non-zero on an unknown mode" do
+      _stdout, stderr, status = run_cli(["nonsense"], chdir: dir)
+
+      expect(status).to eq(1)
+      expect(stderr).to include("Unknown mode")
+    end
+  end
+end


### PR DESCRIPTION
`deprecations run` raised `NoMethodError` on every invocation: it calls `DeprecationTracker.sanitize_mode`, which lived in `deprecation_tracker.rb`, while the CLI only requires `valid_modes`.

Moves `sanitize_mode` to `valid_modes.rb`, next to `valid_mode?`. `deprecation_tracker.rb` already requires that file, so tracker behavior is unchanged and `exe/deprecations` needs no change. Requiring the whole tracker from the CLI was the other option, but that prepends `KernelWarnTracker` onto `Object` and `Kernel` at require time.

Adds a subprocess smoke spec for the executable, the first thing that exercises `exe/` at all. Verified it fails with the original `NoMethodError` when `sanitize_mode` is removed again.
